### PR TITLE
Fix #12: File.keys() and File.__iter__ buggy with escaped keys

### DIFF
--- a/zict/file.py
+++ b/zict/file.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import, division, print_function
 import errno
 import os
 try:
-    from urllib.parse import quote
+    from urllib.parse import quote, unquote
 except ImportError:
-    from urllib import quote
+    from urllib import quote, unquote
 
 from .common import ZictBase
 
@@ -16,6 +16,13 @@ def _safe_key(key):
     """
     # Even directory separators are unsafe.
     return quote(key, safe='')
+
+
+def _unsafe_key(key):
+    """
+    Undo the escaping done by _safe_key().
+    """
+    return unquote(key)
 
 
 class File(ZictBase):
@@ -44,6 +51,9 @@ class File(ZictBase):
         self._keys = set()
         if not os.path.exists(self.directory):
             os.mkdir(self.directory)
+        else:
+            for n in os.listdir(self.directory):
+                self._keys.add(_unsafe_key(n))
 
     def __str__(self):
         return '<File: %s, mode="%s", %d elements>' % (self.directory, self.mode, len(self))

--- a/zict/tests/test_file.py
+++ b/zict/tests/test_file.py
@@ -90,6 +90,10 @@ def test_arbitrary_chars(fn):
             z[key]
         z[key] = b'foo'
         assert z[key] == b'foo'
+        assert list(z) == [key]
+        assert list(z.keys()) == [key]
+        assert list(z.items()) == [(key, b'foo')]
+        assert list(z.values()) == [b'foo']
         del z[key]
         with pytest.raises(KeyError):
             z[key]

--- a/zict/tests/test_file.py
+++ b/zict/tests/test_file.py
@@ -94,6 +94,15 @@ def test_arbitrary_chars(fn):
         assert list(z.keys()) == [key]
         assert list(z.items()) == [(key, b'foo')]
         assert list(z.values()) == [b'foo']
+
+        zz = File(fn)
+        assert zz[key] == b'foo'
+        assert list(zz) == [key]
+        assert list(zz.keys()) == [key]
+        assert list(zz.items()) == [(key, b'foo')]
+        assert list(zz.values()) == [b'foo']
+        del zz
+
         del z[key]
         with pytest.raises(KeyError):
             z[key]


### PR DESCRIPTION
Also speed up keys(), `__iter__`, `__len__` and `__contains__` by avoiding filesystem access.