### PR TITLE
Add LRU.evict method

### DIFF
--- a/zict/lru.py
+++ b/zict/lru.py
@@ -68,11 +68,21 @@ class LRU(ZictBase):
                 cb(key, value)
 
         while self.total_weight > self.n:
-            k, priority = self.heap.popitem()
-            self.total_weight -= self.weights.pop(k)
-            v = self.d.pop(k)
-            for cb in self.on_evict:
-                cb(k, v)
+            self.evict()
+
+    def evict(self):
+        """ Evict least recently used key
+
+        This is typically called from internal use, but can be externally
+        triggered as well.
+        """
+        k, priority = self.heap.popitem()
+        weight = self.weights.pop(k)
+        self.total_weight -= weight
+        v = self.d.pop(k)
+        for cb in self.on_evict:
+            cb(k, v)
+        return k, v, weight
 
     def __delitem__(self, key):
         del self.d[key]

--- a/zict/tests/test_lru.py
+++ b/zict/tests/test_lru.py
@@ -110,3 +110,16 @@ def test_weight():
     lru['a'] = 10000
     assert 'a' not in lru
     assert d == {'y': 4}
+
+
+def test_explicit_evict():
+    d = dict()
+    lru = LRU(10, d)
+
+    lru['x'] = 1
+    lru['y'] = 2
+
+    assert set(d) == {'x', 'y'}
+
+    lru.evict()
+    assert set(d) == {'y'}


### PR DESCRIPTION
This will be useful when managing dask worker memory