### PR TITLE
 Fix install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='zict',
       license='BSD',
       keywords='mutable mapping,dict,dask',
       packages=['zict'],
-      install_requires=[open('requirements.txt').read().strip().split('\n')],
+      install_requires=open('requirements.txt').read().strip().split('\n'),
       long_description=(open('README.rst').read() if os.path.exists('README.rst')
                         else ''),
       zip_safe=False)


### PR DESCRIPTION
`split()` already returns a list, by wrapping the expresion `open(...)....split('\n')` with `[]`, you make it a list of list of str, where a list of str is required.