### PR TITLE
DOC: Add classes missing from API documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *.zip
+doc/build/*

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,9 +31,14 @@ import os
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.viewcode',
     'numpydoc',
 ]
+
+# Generate the API documentation when building
+autosummary_generate = True
+numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -38,11 +38,17 @@ zlib-compressed, directory of files.
 API
 ---
 
-.. autoclass:: zict.lru.LRU
+.. autoclass:: zict.buffer.Buffer
    :members:
 .. autoclass:: zict.file.File
    :members:
 .. autoclass:: zict.func.Func
+   :members:
+.. autoclass:: zict.lmdb.LMDB
+   :members:
+.. autoclass:: zict.lru.LRU
+   :members:
+.. autoclass:: zict.sieve.Sieve
    :members:
 .. autoclass:: zict.zip.Zip
    :members:


### PR DESCRIPTION
- Add missing classes and sort all classes in alphabetical order.
- Configure autosummary extension (which was already used, but in docstrings
  that were previously unpublished).
- Create a _static directory to silence a sphinx warning.

It's possible that these classes were intentionally omitted from the documentation because they are considered less stable. If so, feel free to disregard this PR.