### PR TITLE
fix for too long file names + tests

### DIFF
--- a/zict/file.py
+++ b/zict/file.py
@@ -2,12 +2,21 @@ from __future__ import absolute_import, division, print_function
 
 import errno
 import os
+import pickle
+import uuid
+
 try:
     from urllib.parse import quote, unquote
 except ImportError:
     from urllib import quote, unquote
 
 from .common import ZictBase
+
+
+def _get_uniq_name():
+    uniq_str = str(uuid.uuid4())
+    uniq_str = 'f_' + uniq_str.replace('-', '')
+    return uniq_str
 
 
 def _safe_key(key):
@@ -25,13 +34,62 @@ def _unsafe_key(key):
     return unquote(key)
 
 
+class _WriteAheadLog:
+    """
+    Write ahead log implementation for storing key value pairs to the file
+    Appends to the file key value and action as pickled tuples and reply them back when requested
+    :param log_path: file path to the log file
+    """
+
+    def __init__(self, log_path):
+        self.log_path = log_path
+
+    def write_key_value_and_action(self, key, value, action):
+        """
+        Record key value pair and action to the log file
+        :param key: key to record
+        :param value: value to record
+        :param action: action assigned to key value pair
+        :return: None
+        """
+        with open(self.log_path, 'ab') as f:
+            b = pickle.dumps((key, value, action))
+            bytes_len = len(b)
+            f.write(bytes_len.to_bytes(4, 'big'))
+            f.write(b)
+
+    def get_all_pairs(self):
+        """
+        Get all tuples with key value and action from the log
+        :return: list of tuples with key value and action
+        """
+        if not os.path.exists(self.log_path):
+            return []
+        result = []
+        with open(self.log_path, 'rb') as f:
+            while True:
+                bytes_len_b = f.read(4)
+                if not bytes_len_b:
+                    break
+                bytes_len = int.from_bytes(bytes_len_b, 'big')
+                payload = f.read(bytes_len)
+                key_val_pair = pickle.loads(payload)
+                result.append(key_val_pair)
+
+        return result
+
+
+_WAL_NAME = 'f_a3d4e639575448efa18ed45bdbf5882a.bin'
+
+
+#After that create a package and create a merge request
 class File(ZictBase):
     """ Mutable Mapping interface to a directory
 
     Keys must be strings, values must be bytes
 
     Note this shouldn't be used for interprocess persistence, as keys
-    are cached in memory.
+    are cached in memory.k
 
     Parameters
     ----------
@@ -59,11 +117,23 @@ class File(ZictBase):
         self.directory = directory
         self.mode = mode
         self._keys = set()
+        self._long_key_to_val_map = {}
+        self._wal = _WriteAheadLog(os.path.join(directory, _WAL_NAME))
         if not os.path.exists(self.directory):
             os.mkdir(self.directory)
         else:
             for n in os.listdir(self.directory):
-                self._keys.add(_unsafe_key(n))
+                if n != _WAL_NAME:
+                    self._keys.add(_unsafe_key(n))
+
+        for key, value, action in self._wal.get_all_pairs():
+            if action == 'a':
+                self._long_key_to_val_map[key] = value
+            else:
+                del self._long_key_to_val_map[key]
+
+        for k in self._long_key_to_val_map.keys():
+            self._keys.add(k)
 
     def __str__(self):
         return '<File: %s, mode="%s", %d elements>' % (self.directory, self.mode, len(self))
@@ -73,17 +143,26 @@ class File(ZictBase):
     def __getitem__(self, key):
         if key not in self._keys:
             raise KeyError(key)
+        if key in self._long_key_to_val_map:
+            key = self._long_key_to_val_map[key]
         with open(os.path.join(self.directory, _safe_key(key)), 'rb') as f:
             return f.read()
 
     def __setitem__(self, key, value):
+        original_key = key
+        if len(_safe_key(key)) > 250:
+            short_key = _get_uniq_name()
+            self._long_key_to_val_map[key] = short_key
+            self._wal.write_key_value_and_action(key, short_key, 'a')
+            key = short_key
+
         with open(os.path.join(self.directory, _safe_key(key)), 'wb') as f:
             if isinstance(value, (tuple, list)):
                 for v in value:
                     f.write(v)
             else:
                 f.write(value)
-        self._keys.add(key)
+        self._keys.add(original_key)
 
     def __contains__(self, key):
         return key in self._keys
@@ -96,8 +175,14 @@ class File(ZictBase):
     def __delitem__(self, key):
         if key not in self._keys:
             raise KeyError(key)
+        original_key = key
+        if len(_safe_key(key)) > 250:
+            short_key = self._long_key_to_val_map[key]
+            self._wal.write_key_value_and_action(key, short_key, 'd')
+            key = short_key
+
         os.remove(os.path.join(self.directory, _safe_key(key)))
-        self._keys.remove(key)
+        self._keys.remove(original_key)
 
     def __len__(self):
         return len(self._keys)

--- a/zict/file.py
+++ b/zict/file.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-import errno
 import os
 import pickle
 import uuid
+import struct
 
 try:
     from urllib.parse import quote, unquote
@@ -54,8 +54,7 @@ class _WriteAheadLog:
         """
         with open(self.log_path, 'ab') as f:
             b = pickle.dumps((key, value, action))
-            bytes_len = len(b)
-            f.write(bytes_len.to_bytes(4, 'big'))
+            f.write(struct.pack('>H', len(b)))
             f.write(b)
 
     def get_all_pairs(self):
@@ -68,10 +67,10 @@ class _WriteAheadLog:
         result = []
         with open(self.log_path, 'rb') as f:
             while True:
-                bytes_len_b = f.read(4)
+                bytes_len_b = f.read(2)
                 if not bytes_len_b:
                     break
-                bytes_len = int.from_bytes(bytes_len_b, 'big')
+                bytes_len = struct.unpack('>H', bytes_len_b)[0]
                 payload = f.read(bytes_len)
                 key_val_pair = pickle.loads(payload)
                 result.append(key_val_pair)


### PR DESCRIPTION
Fix for too long keys.
When DASK tries to persist keys larger than 255 bytes than an OS error is thrown saying file name is too long.
This pull request is a fix for this issue.
The code in the pool request maintain backward compatibility.
