### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/zict/tests/test_zip.py
+++ b/zict/tests/test_zip.py
@@ -1,6 +1,10 @@
-from collections import MutableMapping
 import os
 import zipfile
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 import pytest
 

--- a/zict/tests/utils_test.py
+++ b/zict/tests/utils_test.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import MutableMapping
 import random
 import string
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 import pytest
 


### PR DESCRIPTION
Fixes #30 