### PR TITLE
Dup keys fast slow

### DIFF
--- a/zict/buffer.py
+++ b/zict/buffer.py
@@ -79,6 +79,8 @@ class Buffer(ZictBase):
                 del self.slow[key]
             self.fast[key] = value
         else:
+            if key in self.fast:
+                del self.fast[key]
             self.slow[key] = value
 
     def __delitem__(self, key):

--- a/zict/buffer.py
+++ b/zict/buffer.py
@@ -72,7 +72,6 @@ class Buffer(ZictBase):
             raise KeyError(key)
 
     def __setitem__(self, key, value):
-        weight = self.weight(key, value)
         # Avoid useless movement for heavy values
         if self.weight(key, value) <= self.n:
             if key in self.slow:

--- a/zict/tests/test_buffer.py
+++ b/zict/tests/test_buffer.py
@@ -63,6 +63,31 @@ def test_simple():
     assert buff['b'] == 1000
 
 
+def test_setkey_fastslow():
+
+    a = dict()
+    b = dict()
+    buff = Buffer(a, b, n=10, weight=lambda k, v: v)
+    for first, second in [
+        (1, 12),
+        (12, 1)
+    ]:
+        buff['a'] = first
+        assert buff['a'] == first
+        buff['a'] = second
+        assert buff['a'] == second
+
+        fast_keys = set(buff.fast)
+        slow_keys = set(buff.slow)
+        assert not (fast_keys & slow_keys)
+        assert fast_keys | slow_keys == set(buff)
+
+        del buff['a']
+        assert 'a' not in buff
+        assert 'a' not in a
+        assert 'a' not in b
+
+
 def test_mapping():
     """
     Test mapping interface for Buffer().

--- a/zict/tests/test_buffer.py
+++ b/zict/tests/test_buffer.py
@@ -63,7 +63,7 @@ def test_simple():
     assert buff['b'] == 1000
 
 
-def test_setkey_fastslow():
+def test_setitem_avoid_fast_slow_duplicate():
 
     a = dict()
     b = dict()


### PR DESCRIPTION
Two changes here to the Buffer

* Only call the weight function once during setitem
* In case a key, currently stored in fast, is overwritten by a large value, delete the fast entry