### PR TITLE
Fix dask cuda worker's race condition failure

### DIFF
--- a/zict/file.py
+++ b/zict/file.py
@@ -60,7 +60,7 @@ class File(ZictBase):
         self.mode = mode
         self._keys = set()
         if not os.path.exists(self.directory):
-            os.mkdir(self.directory)
+            os.makedirs(self.directory, exist_ok=True)
         else:
             for n in os.listdir(self.directory):
                 self._keys.add(_unsafe_key(n))


### PR DESCRIPTION
- Fixing - https://github.com/rapidsai/dask-cuda/issues/232

- issue is observed during multiple dask cuda worker creation
  and some of the dask-cuda worker died after failing with EEXIST
  error.