### PR TITLE
Drop Python 2 / 3.5 and add Python 3.7 / 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: python
 
 matrix:
   include:
-    - python: 2.7
-    - python: 3.5
     - python: 3.6
+    - python: 3.7
+    - python: 3.8
 
 install:
   # Install conda

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,10 @@ setup(name='zict',
       install_requires=open('requirements.txt').read().strip().split('\n'),
       long_description=(open('README.rst').read() if os.path.exists('README.rst')
                         else ''),
+      classifiers=[
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Programming Language :: Python :: 3.8",
+      ],
       zip_safe=False)

--- a/zict/common.py
+++ b/zict/common.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 try:
     from collections.abc import Mapping, MutableMapping

--- a/zict/file.py
+++ b/zict/file.py
@@ -1,11 +1,7 @@
-from __future__ import absolute_import, division, print_function
 
 import errno
 import os
-try:
-    from urllib.parse import quote, unquote
-except ImportError:
-    from urllib import quote, unquote
+from urllib.parse import quote, unquote
 
 from .common import ZictBase
 

--- a/zict/func.py
+++ b/zict/func.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 from .common import ZictBase, close
 

--- a/zict/lmdb.py
+++ b/zict/lmdb.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/zict/lmdb.py
+++ b/zict/lmdb.py
@@ -5,19 +5,11 @@ import sys
 from .common import ZictBase
 
 
-if sys.version_info >= (3,):
-    def _encode_key(key):
-        return key.encode('latin1')
+def _encode_key(key):
+    return key.encode('latin1')
 
-    def _decode_key(key):
-        return key.decode('latin1')
-
-else:
-    def _encode_key(key):
-        return key
-
-    def _decode_key(key):
-        return key
+def _decode_key(key):
+    return key.decode('latin1')
 
 
 class LMDB(ZictBase):

--- a/zict/lru.py
+++ b/zict/lru.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 from heapdict import heapdict
 

--- a/zict/sieve.py
+++ b/zict/sieve.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict
 from itertools import chain

--- a/zict/tests/test_buffer.py
+++ b/zict/tests/test_buffer.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 from zict import Buffer
 from . import utils_test

--- a/zict/tests/test_file.py
+++ b/zict/tests/test_file.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 import os
 import shutil

--- a/zict/tests/test_func.py
+++ b/zict/tests/test_func.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 from zict import Func
 from . import utils_test

--- a/zict/tests/test_lmdb.py
+++ b/zict/tests/test_lmdb.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 import gc
 import os

--- a/zict/tests/test_lru.py
+++ b/zict/tests/test_lru.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 from zict import LRU
 from . import utils_test

--- a/zict/tests/test_sieve.py
+++ b/zict/tests/test_sieve.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 import sys
 

--- a/zict/tests/utils_test.py
+++ b/zict/tests/utils_test.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 import random
 import string

--- a/zict/zip.py
+++ b/zict/zip.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 try:
     from collections.abc import MutableMapping

--- a/zict/zip.py
+++ b/zict/zip.py
@@ -3,7 +3,6 @@ try:
     from collections.abc import MutableMapping
 except ImportError:
     from collections import MutableMapping
-import sys
 import zipfile
 
 
@@ -42,7 +41,7 @@ class Zip(MutableMapping):
         return self.file.read(key)
 
     def __setitem__(self, key, value):
-        self.file.writestr(key, to_bytes(value))
+        self.file.writestr(key, value)
 
     def keys(self):
         return (zi.filename for zi in self.file.filelist)
@@ -76,12 +75,3 @@ class Zip(MutableMapping):
 
     def __exit__(self, type, value, traceback):
         self.close()
-
-
-if sys.version_info[0] == 2:
-    def to_bytes(x):
-        if isinstance(x, bytearray):
-            return bytes(x)
-        return x
-else:
-    to_bytes = lambda x: x


### PR DESCRIPTION
Python 2 has reached EOL and many other projects in the ecosystem (e.g. Dask, NumPy, Pandas) have dropped support for Python 3.5 (see [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html))