### PR TITLE
Avoid deprecated `pytest.yield_fixture` usage

### DIFF
--- a/zict/tests/test_file.py
+++ b/zict/tests/test_file.py
@@ -7,7 +7,7 @@ from zict.file import File
 from . import utils_test
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def fn():
     filename = ".tmp"
     if os.path.exists(filename):

--- a/zict/tests/test_lmdb.py
+++ b/zict/tests/test_lmdb.py
@@ -9,7 +9,7 @@ from zict.lmdb import LMDB
 from . import utils_test
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def fn():
     dirname = tempfile.mkdtemp(prefix="test_lmdb-")
     try:

--- a/zict/tests/test_zip.py
+++ b/zict/tests/test_zip.py
@@ -11,7 +11,7 @@ import pytest
 from zict import Zip
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def fn():
     filename = ".tmp.zip"
     if os.path.exists(filename):


### PR DESCRIPTION
This removes the following class of warnings when running tests

```python
 zict/tests/test_file.py:11
  /home/runner/work/zict/zict/zict/tests/test_file.py:11: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    def fn():
```