### PR TITLE
Allow file `mmap`ing

### DIFF
--- a/zict/file.py
+++ b/zict/file.py
@@ -80,8 +80,7 @@ class File(ZictBase):
         fn = os.path.join(self.directory, _safe_key(key))
         with open(fn, "wb") as fh:
             if isinstance(value, (tuple, list)):
-                for v in value:
-                    fh.write(v)
+                fh.writelines(value)
             else:
                 fh.write(value)
         self._keys.add(key)

--- a/zict/file.py
+++ b/zict/file.py
@@ -72,16 +72,18 @@ class File(ZictBase):
     def __getitem__(self, key):
         if key not in self._keys:
             raise KeyError(key)
-        with open(os.path.join(self.directory, _safe_key(key)), "rb") as f:
-            return f.read()
+        fn = os.path.join(self.directory, _safe_key(key))
+        with open(fn, "rb") as fh:
+            return fh.read()
 
     def __setitem__(self, key, value):
-        with open(os.path.join(self.directory, _safe_key(key)), "wb") as f:
+        fn = os.path.join(self.directory, _safe_key(key))
+        with open(fn, "wb") as fh:
             if isinstance(value, (tuple, list)):
                 for v in value:
-                    f.write(v)
+                    fh.write(v)
             else:
-                f.write(value)
+                fh.write(value)
         self._keys.add(key)
 
     def __contains__(self, key):

--- a/zict/tests/test_file.py
+++ b/zict/tests/test_file.py
@@ -39,6 +39,17 @@ def test_implementation(fn):
     assert "x" in z
 
 
+def test_memmap_implementation(fn):
+    z = File(fn, memmap=True)
+    assert not z
+
+    z["x"] = b"123"
+    assert os.listdir(fn) == ["x"]
+    assert z["x"] == memoryview(b"123")
+
+    assert "x" in z
+
+
 def test_str(fn):
     z = File(fn)
     assert fn in str(z)


### PR DESCRIPTION
Adds a flag to `File` to allow data to be read in with `mmap`. This can be useful in a few ways.

1. Other processes loading the same data can reuse the same memory
2. Reading data from disk can be deferred until needed
3. The OS (instead of the application) manages mapping data from disk to memory (so it can more easily free it as well)