### PR TITLE
Drop Python 3.6; add 3.9 and 3.10; use pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,16 @@
+name: Linting
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+jobs:
+  checks:
+    name: pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on: [push, pull_request]
 
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout source
@@ -25,19 +25,11 @@ jobs:
 
       - name: Install dependencies
         shell: bash -l {0}
-        run: conda install -c conda-forge pytest flake8 black heapdict python-lmdb psutil
+        run: conda install -c conda-forge pytest heapdict python-lmdb psutil
 
       - name: Install zict
         shell: bash -l {0}
         run: python setup.py install
-
-      - name: Run flake8
-        shell: bash -l {0}
-        run: flake8 zict
-
-      - name: Run black
-        shell: bash -l {0}
-        run: black --check zict
 
       - name: Run pytest
         shell: bash -l {0}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.zip
 doc/build/*
+.idea

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  -   repo: https://github.com/psf/black
+      rev: 22.1.0
+      hooks:
+      - id: black
+        language_version: python3
+        exclude: versioneer.py
+        args:
+          - --target-version=py37
+  -   repo: https://gitlab.com/pycqa/flake8
+      rev: 4.0.1
+      hooks:
+      - id: flake8
+        language_version: python3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
-Dask is a community maintained project. We welcome contributions in the form of bug reports, documentation, code, design proposals, and more. 
+Dask is a community maintained project. We welcome contributions in the form of bug
+reports, documentation, code, design proposals, and more.
 
-For general information on how to contribute see https://docs.dask.org/en/latest/develop.html.
+For general information on how to contribute see
+https://docs.dask.org/en/latest/develop.html.

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,13 +1,22 @@
 Changelog
 =========
 
+2.1.0 - Unreleased
+------------------
+- LRU and Buffer now deal with exceptions raised by the callbacks - namely, OSError
+  raised when the disk is full (:pr`48`) `Naty Clementi`_, `Guido Imperiale`_
+- Dropped support for Python 3.6; added support for Python 3.9 and 3.10 (:pr:`55`)
+  `Guido Imperiale`_
+
+
 2.0.0 - 2020-02-28
 ------------------
 
 - Create ``CONTRIBUTING.md`` (:pr:`28`) `Jacob Tomlinson`_
-- Import ABC from ``collections.abc`` instead of ``collections`` for Python 3.9 compatibility (:pr:`31`) `Karthikeyan Singaravelan`_
+- Import ABC from ``collections.abc`` instead of ``collections`` for Python 3.9
+  compatibility (:pr:`31`) `Karthikeyan Singaravelan`_
 - Drop Python 2 / 3.5 and add Python 3.7 / 3.8 support (:pr:`34`) `James Bourbeau`_
-- Duplicate keys fast slow (:pr:`32`) `fjetter`_
+- Duplicate keys fast slow (:pr:`32`) `Florian Jetter`_
 - Fix dask cuda worker's race condition failure (:pr:`33`) `Pradipta Ghosh`_
 - Changed default ``lmdb`` encoding to ``utf-8`` (:pr:`36`) `Alex Davies`_
 - Add code linting and style check (:pr:`35`) `James Bourbeau`_
@@ -15,6 +24,8 @@ Changelog
 .. _`Jacob Tomlinson`: https://github.com/jacobtomlinson
 .. _`Karthikeyan Singaravelan`: https://github.com/tirkarthi
 .. _`James Bourbeau`: https://github.com/jrbourbeau
-.. _`fjetter`: https://github.com/fjetter
+.. _`Florian Jetter`: https://github.com/fjetter
 .. _`Pradipta Ghosh`: https://github.com/pradghos
 .. _`Alex Davies`: https://github.com/traverseda
+.. _`Naty Clementi`: https://github.com/ncclementi
+.. _`Guido Imperiale`: https://github.com/crusaderky

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-#
 # zict documentation build configuration file, created by
 # sphinx-quickstart on Sat Apr  2 14:56:27 2016.
 #
@@ -13,28 +11,25 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.extlinks',
-    'numpydoc',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.extlinks",
+    "numpydoc",
 ]
 
 # Generate the API documentation when building
@@ -42,23 +37,23 @@ autosummary_generate = True
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'zict'
-copyright = '2016, Matthew Rocklin'
-author = 'Matthew Rocklin'
+project = "zict"
+copyright = "2016, Matthew Rocklin"
+author = "Matthew Rocklin"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -66,6 +61,7 @@ author = 'Matthew Rocklin'
 #
 # The short X.Y version.
 import zict
+
 version = zict.__version__
 # The full version, including alpha/beta/rc tags.
 release = version
@@ -86,9 +82,9 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -96,27 +92,27 @@ exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -126,156 +122,149 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'h', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'r', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'zictdoc'
+htmlhelp_basename = "zictdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
+    # Latex figure (float) alignment
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'zict.tex', 'zict Documentation',
-     'Matthew Rocklin', 'manual'),
+    (master_doc, "zict.tex", "zict Documentation", "Matthew Rocklin", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'zict', 'zict Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "zict", "zict Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -284,22 +273,28 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'zict', 'zict Documentation',
-     author, 'zict', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "zict",
+        "zict Documentation",
+        author,
+        "zict",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 
 # -- Options for Epub output ----------------------------------------------
@@ -311,62 +306,62 @@ epub_publisher = author
 epub_copyright = copyright
 
 # The basename for the epub file. It defaults to the project name.
-#epub_basename = project
+# epub_basename = project
 
 # The HTML theme for the epub output. Since the default themes are not
 # optimized for small screen space, using the same theme for HTML and epub
 # output is usually not wise. This defaults to 'epub', a theme designed to save
 # visual space.
-#epub_theme = 'epub'
+# epub_theme = 'epub'
 
 # The language of the text. It defaults to the language option
 # or 'en' if the language is not set.
-#epub_language = ''
+# epub_language = ''
 
 # The scheme of the identifier. Typical schemes are ISBN or URL.
-#epub_scheme = ''
+# epub_scheme = ''
 
 # The unique identifier of the text. This can be a ISBN number
 # or the project homepage.
-#epub_identifier = ''
+# epub_identifier = ''
 
 # A unique identification for the text.
-#epub_uid = ''
+# epub_uid = ''
 
 # A tuple containing the cover image and cover page html template filenames.
-#epub_cover = ()
+# epub_cover = ()
 
 # A sequence of (type, uri, title) tuples for the guide element of content.opf.
-#epub_guide = ()
+# epub_guide = ()
 
 # HTML files that should be inserted before the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
-#epub_pre_files = []
+# epub_pre_files = []
 
 # HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
-#epub_post_files = []
+# epub_post_files = []
 
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
+epub_exclude_files = ["search.html"]
 
 # The depth of the table of contents in toc.ncx.
-#epub_tocdepth = 3
+# epub_tocdepth = 3
 
 # Allow duplicate toc entries.
-#epub_tocdup = True
+# epub_tocdup = True
 
 # Choose between 'default' and 'includehidden'.
-#epub_tocscope = 'default'
+# epub_tocscope = 'default'
 
 # Fix unsupported image types using the Pillow.
-#epub_fix_images = False
+# epub_fix_images = False
 
 # Scale large images.
-#epub_max_image_width = 0
+# epub_max_image_width = 0
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#epub_show_urls = 'inline'
+# epub_show_urls = 'inline'
 
 # If false, no index is generated.
-#epub_use_index = True
+# epub_use_index = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,12 +3,16 @@
 # https://flake8.readthedocs.io/en/latest/user/configuration.html
 # https://flake8.readthedocs.io/en/latest/user/error-codes.html
 
-# Note: there cannot be spaces after comma's here
+# Aligned with black https://github.com/psf/black/blob/main/.flake8
+extend-ignore = E203, E266, E501
+# Note: there cannot be spaces after commas here
 exclude = __init__.py
-max-line-length = 120
 ignore =
+    E4,         # Import formatting
     E731,       # Assigning lambda expression
-    E741        # Ambiguous variable names
+    W503,       # line break before binary operator
+
+max-line-length = 88
 
 [tool:pytest]
 addopts = -v --doctest-modules

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="zict",
-    version="2.1.0.dev1",
+    version="2.1.0.dev2",
     description="Mutable mapping tools",
     url="http://zict.readthedocs.io/en/latest/",
     maintainer="Matthew Rocklin",
@@ -20,9 +20,10 @@ setup(
     ),
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     zip_safe=False,
 )

--- a/zict/lmdb.py
+++ b/zict/lmdb.py
@@ -33,7 +33,7 @@ class LMDB(ZictBase):
 
         # map_size is the maximum database size but shouldn't fill up the
         # virtual address space
-        map_size = 1 << 40 if sys.maxsize >= 2 ** 32 else 1 << 28
+        map_size = 1 << 40 if sys.maxsize >= 2**32 else 1 << 28
         # writemap requires sparse file support otherwise the whole
         # `map_size` may be reserved up front on disk
         writemap = sys.platform.startswith("linux")

--- a/zict/tests/utils_test.py
+++ b/zict/tests/utils_test.py
@@ -11,15 +11,15 @@ import pytest
 
 def generate_random_strings(n, min_len, max_len):
     r = random.Random(42)
-    l = []
+    out = []
     chars = string.ascii_lowercase + string.digits
 
     for i in range(n):
         nchars = r.randint(min_len, max_len)
         s = "".join(r.choice(chars) for _ in range(nchars))
-        l.append(s)
+        out.append(s)
 
-    return l
+    return out
 
 
 def to_bytestring(s):


### PR DESCRIPTION
- Drop Python 3.6
- Formally add support for Python 3.9 and 3.10
- Migrate code linters to pre-commit
- Fix failures vs. latest version of black (closes #54)
- Pin versions of black and flake8