### PR TITLE
Update `README` badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,5 +6,5 @@ Zict
 Mutable Mapping interfaces.  See documentation_.
 
 .. _documentation: http://zict.readthedocs.io/en/latest/
-.. |Build Status| image:: https://github.com/dask/zict/workflows/CI/badge.svg
-   :target: https://github.com/dask/zict/actions?query=workflow%3ACI
+.. |Build Status| image:: https://github.com/dask/zict/actions/workflows/test.yml/badge.svg
+   :target: https://github.com/dask/zict/actions/workflows/test.yml

--- a/README.rst
+++ b/README.rst
@@ -6,5 +6,7 @@ Zict
 Mutable Mapping interfaces.  See documentation_.
 
 .. _documentation: http://zict.readthedocs.io/en/latest/
-.. |Build Status| image:: https://github.com/dask/zict/actions/workflows/test.yml/badge.svg
+.. |Build Status| image:: https://github.com/dask/zict/actions/workflows/pre-commit.yml/badge.svg
+   :target: https://github.com/dask/zict/actions/workflows/pre-commit.yml
+   image:: https://github.com/dask/zict/actions/workflows/test.yml/badge.svg
    :target: https://github.com/dask/zict/actions/workflows/test.yml

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
 Zict
 ====
 
-|Build Status|
+|Build Status| |Linting|
 
 Mutable Mapping interfaces.  See documentation_.
 
 .. _documentation: http://zict.readthedocs.io/en/latest/
-.. |Build Status| image:: https://github.com/dask/zict/actions/workflows/pre-commit.yml/badge.svg
-   :target: https://github.com/dask/zict/actions/workflows/pre-commit.yml
-   image:: https://github.com/dask/zict/actions/workflows/test.yml/badge.svg
+.. |Build Status| image:: https://github.com/dask/zict/actions/workflows/test.yml/badge.svg
    :target: https://github.com/dask/zict/actions/workflows/test.yml
+.. |Linting| image:: https://github.com/dask/zict/actions/workflows/pre-commit.yml/badge.svg
+   :target: https://github.com/dask/zict/actions/workflows/pre-commit.yml


### PR DESCRIPTION
In https://github.com/dask/zict/pull/55 we updated the name of the GHA that runs our tests. This is a small follow up PR to update the status badge on our README accordingly (currently it's red, but should be green)

cc @crusaderky when you get a moment 