### PR TITLE
Run `isort` to fix lint

### DIFF
--- a/zict/file.py
+++ b/zict/file.py
@@ -1,5 +1,5 @@
-import os
 import mmap
+import os
 from urllib.parse import quote, unquote
 
 from .common import ZictBase


### PR DESCRIPTION
Fixes a lint issue identified in [this CI job]( https://github.com/dask/zict/runs/5304702200?check_suite_focus=true ) of commit ( https://github.com/dask/zict/commit/65f03c1cf0c472b3f3c73012d07d44910b2349dc ).