### PR TITLE
Add `python_requires` to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     license="BSD",
     keywords="mutable mapping,dict,dask",
     packages=["zict"],
+    python_requires=">=3.7",
     install_requires=open("requirements.txt").read().strip().split("\n"),
     long_description=(
         open("README.rst").read() if os.path.exists("README.rst") else ""


### PR DESCRIPTION
- This prevents pip from incorrectly installing 2.1.0 in Python 2
- I detected this problem in https://github.com/spyder-ide/spyder-kernels/pull/374 because that package still supports Python 2.