### PR TITLE
Update black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args:
           - --py37-plus
   -   repo: https://github.com/psf/black
-      rev: 22.1.0
+      rev: 22.3.0
       hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
Updating helps avoid 

```
black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repol6p19lv1/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/.cache/pre-commit/repol6p19lv1/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1423, in patched_main
    patch_click()
  File "/home/runner/.cache/pre-commit/repol6p19lv1/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1409, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repol6p19lv1/py_env-python3/lib/python3.10/site-packages/click/__init__.py)
```

when running this pre-commit hook 