### PR TITLE
[DOC] `File(..., memmap=False)`

### DIFF
--- a/zict/file.py
+++ b/zict/file.py
@@ -35,6 +35,7 @@ class File(ZictBase[str, bytes]):
     ----------
     directory: string
     mode: string, ('r', 'w', 'a'), defaults to 'a'
+    memmap: bool, use `mmap` for reading, defaults to `False`
 
     Examples
     --------


### PR DESCRIPTION
Provide a brief blurb about the `File` constructor's `memmap` flag.

xref: https://github.com/dask/zict/pull/70#pullrequestreview-1130135194

cc @jrbourbeau