### PR TITLE
Require Python 3.8 as a minimum

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,14 +14,14 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py37-plus
+          - --py38-plus
   -   repo: https://github.com/psf/black
       rev: 22.3.0
       hooks:
       - id: black
         language_version: python3
         args:
-          - --target-version=py37
+          - --target-version=py38
   -   repo: https://gitlab.com/pycqa/flake8
       rev: 4.0.1
       hooks:

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -9,6 +9,7 @@ Changelog
   memory (:pr:`64`) `Guido Imperiale`_
 - Added new classes ``zict.Cache`` and ``zict.WeakRefCache``
   (:pr:`65`) `Guido Imperiale`_
+- Require Python 3.8 (drop Python 3.7) (:pr:`72`) `jakirkham`_
 
 
 2.1.0 - 2022-02-25

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,7 +29,7 @@ classifiers =
 packages = zict
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     heapdict
 


### PR DESCRIPTION
Bump the minimum Python version to 3.8. Drop Python 3.7. As Python 3.11 is planned to be released Monday (2022-10-24) (see PEP link below), this also makes room for Python 3.11 to be added.

https://peps.python.org/pep-0664/#schedule