### PR TITLE
Remove heapdict dependency; speed up LRU; non-empty LRU init

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash -l {0}
-        run: mamba install pytest heapdict python-lmdb psutil
+        run: mamba install pytest python-lmdb psutil
 
       - name: Install zict
         shell: bash -l {0}

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,1 @@
 numpydoc
-heapdict

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,9 @@ Changelog
 ------------------
 - ``File.__getitem__`` now returns bytearray instead of bytes. This prevents a memcpy
   when deserializing numpy arrays with dask. (:pr:`74`) `Guido Imperiale`_
+- Removed dependency from ``heapdict``; sped up ``LRU``. (:pr:`77`) `Guido Imperiale`_
+- Fixed broken ``LRU`` state when the underlying mapping starts non-empty.
+  (:pr:`77`) `Guido Imperiale`_
 
 
 2.2.0 - 2022-04-28

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-heapdict

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.htm
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    heapdict
 
 [options.package_data]
 zict =

--- a/zict/buffer.py
+++ b/zict/buffer.py
@@ -68,8 +68,7 @@ class Buffer(ZictBase[KT, VT]):
         self.fast = LRU(n, fast, weight=weight, on_evict=[self.fast_to_slow])
         self.slow = slow
         self.n = n
-        # FIXME https://github.com/python/mypy/issues/708
-        self.weight = weight  # type: ignore
+        self.weight = weight
         if callable(fast_to_slow_callbacks):
             fast_to_slow_callbacks = [fast_to_slow_callbacks]
         if callable(slow_to_fast_callbacks):

--- a/zict/func.py
+++ b/zict/func.py
@@ -46,9 +46,8 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
         load: Callable[[WT], VT],
         d: MutableMapping[KT, WT],
     ):
-        # FIXME https://github.com/python/mypy/issues/708
-        self.dump = dump  # type: ignore
-        self.load = load  # type: ignore
+        self.dump = dump
+        self.load = load
         self.d = d
 
     def __getitem__(self, key: KT) -> VT:

--- a/zict/sieve.py
+++ b/zict/sieve.py
@@ -47,8 +47,7 @@ class Sieve(ZictBase[KT, VT], Generic[KT, VT, MKT]):
         selector: Callable[[KT, VT], MKT],
     ):
         self.mappings = mappings
-        # FIXME https://github.com/python/mypy/issues/708
-        self.selector = selector  # type: ignore
+        self.selector = selector
         self.key_to_mapping = {}
 
     def __getitem__(self, key: KT) -> VT:


### PR DESCRIPTION
- Remove dependency from heapdict
- Speed up LRU
- Fix broken LRU state if the underlying mapping is non-empty at init

### Benchmark
```python
In [1] from zict import LRU

In [2]: d = LRU(100, {})

In [3]: %time for i in range(1000): d[i] = i
```
Before: 2.29 ms
After: 995 us