### PR TITLE
MacOSX and Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,22 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }} ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        include:
+          - os: windows-latest
+            python-version: "3.7"
+          - os: windows-latest
+            python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.7"
+          - os: macos-latest
+            python-version: "3.11"
 
     steps:
       - name: Checkout source

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 ------------------
 - ``File.__getitem__`` now returns bytearray instead of bytes. This prevents a memcpy
   when deserializing numpy arrays with dask. (:pr:`74`) `Guido Imperiale`_
+- ``File`` and ``LMDB`` now support :class:`pathlib.Path` and pytest's ``tmpdir``.
+  (:pr:`78`) `Guido Imperiale`_
+- ``LMDB`` now uses memory-mapped I/O on MacOSX and is usable on Windows.
+  (:pr:`78`) `Guido Imperiale`_
 
 
 2.2.0 - 2022-04-28

--- a/zict/tests/test_lmdb.py
+++ b/zict/tests/test_lmdb.py
@@ -1,67 +1,77 @@
 import gc
 import os
-import shutil
-import tempfile
+import pathlib
+import sys
 
 import pytest
 
 from zict.lmdb import LMDB
 from zict.tests import utils_test
 
-
-@pytest.fixture
-def fn():
-    dirname = tempfile.mkdtemp(prefix="test_lmdb-")
-    try:
-        yield dirname
-    finally:
-        if os.path.exists(dirname):
-            shutil.rmtree(dirname)
+pytest.importorskip("lmdb")
 
 
-def test_mapping(fn):
+@pytest.mark.parametrize("dirtype", [str, pathlib.Path, lambda x: x])
+def test_dirtypes(tmpdir, dirtype):
+    z = LMDB(tmpdir)
+    z["x"] = b"123"
+    assert z["x"] == b"123"
+    del z["x"]
+
+
+def test_mapping(tmpdir):
     """
     Test mapping interface for LMDB().
     """
-    z = LMDB(fn)
+    z = LMDB(tmpdir)
     utils_test.check_mapping(z)
 
 
-def test_reuse(fn):
+def test_reuse(tmpdir):
     """
     Test persistence of a LMDB() mapping.
     """
-    with LMDB(fn) as z:
+    with LMDB(tmpdir) as z:
         assert len(z) == 0
         z["abc"] = b"123"
 
-    with LMDB(fn) as z:
+    with LMDB(tmpdir) as z:
         assert len(z) == 1
         assert z["abc"] == b"123"
 
 
-def test_creates_dir(fn):
-    with LMDB(fn):
-        assert os.path.isdir(fn)
+def test_creates_dir(tmpdir):
+    with LMDB(tmpdir):
+        assert os.path.isdir(tmpdir)
 
 
-def test_file_descriptors_dont_leak(fn):
+@pytest.mark.skipif(sys.platform == "win32", reason="requires psutil.Process.num_fds")
+def test_file_descriptors_dont_leak(tmpdir):
     psutil = pytest.importorskip("psutil")
     proc = psutil.Process()
     before = proc.num_fds()
 
-    z = LMDB(fn)
+    z = LMDB(tmpdir)
     del z
     gc.collect()
 
     assert proc.num_fds() == before
 
-    z = LMDB(fn)
+    z = LMDB(tmpdir)
     z.close()
 
     assert proc.num_fds() == before
 
-    with LMDB(fn) as z:
+    with LMDB(tmpdir) as z:
         pass
 
     assert proc.num_fds() == before
+
+
+def test_map_size(tmpdir):
+    import lmdb
+
+    z = LMDB(tmpdir, map_size=2**20)
+    z["x"] = b"x" * 2**19
+    with pytest.raises(lmdb.MapFullError):
+        z["y"] = b"x" * 2**20


### PR DESCRIPTION
- Run CI on Windows and MacOSX
- Add support for pathlib and pytest tmpdir to File and LMDB
- Enable LMDB memory mapped I/O on MacOSX
- Fix broken LMDB on Windows (the full file is allocated in advance, regardless of memory mapping)