### PR TITLE
Sphinx and mypy tweaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,19 @@ repos:
     hooks:
       - id: flake8
         language_version: python3
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+        types_or: [rst, markdown]
+        files: doc
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
     hooks:
       - id: mypy
+        # Override default --ignore-missing-imports
+        # Use setup.cfg if possible instead of adding command line parameters here
+        args: [ --warn-unused-configs ]
         additional_dependencies:
           # Type stubs
           - types-psutil

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -79,7 +79,7 @@ extlinks = {
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -38,23 +38,25 @@ zlib-compressed, directory of files.
 API
 ---
 
-.. autoclass:: zict.buffer.Buffer
+.. currentmodule:: zict
+
+.. autoclass:: Buffer
    :members:
-.. autoclass:: zict.cache.Cache
+.. autoclass:: Cache
    :members:
-.. autoclass:: zict.cache.WeakValueMapping
+.. autoclass:: WeakValueMapping
    :members:
-.. autoclass:: zict.file.File
+.. autoclass:: File
    :members:
-.. autoclass:: zict.func.Func
+.. autoclass:: Func
    :members:
-.. autoclass:: zict.lmdb.LMDB
+.. autoclass:: LMDB
    :members:
-.. autoclass:: zict.lru.LRU
+.. autoclass:: LRU
    :members:
-.. autoclass:: zict.sieve.Sieve
+.. autoclass:: Sieve
    :members:
-.. autoclass:: zict.zip.Zip
+.. autoclass:: Zip
    :members:
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,3 +70,24 @@ skip_gitignore = true
 force_to_top = true
 default_section = THIRDPARTY
 known_first_party = zict
+
+
+[mypy]
+# Silence errors about Python 3.9-style delayed type annotations on Python 3.7/3.8
+python_version = 3.9
+# See https://github.com/python/mypy/issues/12286 for automatic multi-platform support
+platform = linux
+# platform = win32
+# platform = darwin
+allow_incomplete_defs = false
+allow_untyped_decorators = false
+allow_untyped_defs = false
+ignore_missing_imports = true
+no_implicit_optional = true
+show_error_codes = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unreachable = true
+
+[mypy-zict.tests.*]
+allow_untyped_defs = true

--- a/zict/__init__.py
+++ b/zict/__init__.py
@@ -1,11 +1,12 @@
-from zict.buffer import Buffer
-from zict.cache import Cache, WeakValueMapping
-from zict.file import File
-from zict.func import Func
-from zict.lmdb import LMDB
-from zict.lru import LRU
-from zict.sieve import Sieve
-from zict.zip import Zip
+from zict.buffer import Buffer as Buffer
+from zict.cache import Cache as Cache
+from zict.cache import WeakValueMapping as WeakValueMapping
+from zict.file import File as File
+from zict.func import Func as Func
+from zict.lmdb import LMDB as LMDB
+from zict.lru import LRU as LRU
+from zict.sieve import Sieve as Sieve
+from zict.zip import Zip as Zip
 
 # Must be kept aligned with setup.cfg
 __version__ = "2.3.0"

--- a/zict/buffer.py
+++ b/zict/buffer.py
@@ -34,7 +34,7 @@ class Buffer(ZictBase[KT, VT]):
 
     Examples
     --------
-    >>> fast = dict()
+    >>> fast = {}
     >>> slow = Func(dumps, loads, File('storage/'))  # doctest: +SKIP
     >>> def weight(k, v):
     ...     return sys.getsizeof(v)
@@ -90,7 +90,7 @@ class Buffer(ZictBase[KT, VT]):
     def slow_to_fast(self, key: KT) -> VT:
         value = self.slow[key]
         # Avoid useless movement for heavy values
-        w = self.weight(key, value)  # type: ignore
+        w = self.weight(key, value)
         if w <= self.n:
             del self.slow[key]
             self.fast[key] = value

--- a/zict/common.py
+++ b/zict/common.py
@@ -26,7 +26,7 @@ class ZictBase(MutableMapping[KT, VT]):
     def update(self, **kwargs: VT) -> None:
         ...
 
-    def update(*args, **kwds):
+    def update(*args, **kwargs):  # type: ignore[no-untyped-def]
         # Boilerplate for implementing an update() method
         if not args:
             raise TypeError(
@@ -44,8 +44,8 @@ class ZictBase(MutableMapping[KT, VT]):
             else:
                 # Assuming (key, value) pairs
                 items = other
-        if kwds:
-            items = chain(items, kwds.items())
+        if kwargs:
+            items = chain(items, kwargs.items())
         self._do_update(items)
 
     def _do_update(self, items: Iterable[tuple[KT, VT]]) -> None:
@@ -59,7 +59,7 @@ class ZictBase(MutableMapping[KT, VT]):
     def __enter__(self: T) -> T:
         return self
 
-    def __exit__(self, *args) -> None:
+    def __exit__(self, *args: Any) -> None:
         self.close()
 
 

--- a/zict/func.py
+++ b/zict/func.py
@@ -27,7 +27,7 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
     >>> def halve(x):
     ...     return x / 2
 
-    >>> d = dict()
+    >>> d = {}
     >>> f = Func(double, halve, d)
     >>> f['x'] = 10
     >>> d
@@ -51,10 +51,10 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
         self.d = d
 
     def __getitem__(self, key: KT) -> VT:
-        return self.load(self.d[key])  # type: ignore
+        return self.load(self.d[key])
 
     def __setitem__(self, key: KT, value: VT) -> None:
-        self.d[key] = self.dump(value)  # type: ignore
+        self.d[key] = self.dump(value)
 
     def __contains__(self, key: object) -> bool:
         return key in self.d
@@ -67,13 +67,13 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
 
     # FIXME dictionary views https://github.com/dask/zict/issues/61
     def values(self) -> Iterator[VT]:  # type: ignore
-        return (self.load(v) for v in self.d.values())  # type: ignore
+        return (self.load(v) for v in self.d.values())
 
     def items(self) -> Iterator[tuple[KT, VT]]:  # type: ignore
-        return ((k, self.load(v)) for k, v in self.d.items())  # type: ignore
+        return ((k, self.load(v)) for k, v in self.d.items())
 
     def _do_update(self, items: Iterable[tuple[KT, VT]]) -> None:
-        it = ((k, self.dump(v)) for k, v in items)  # type: ignore
+        it = ((k, self.dump(v)) for k, v in items)
         self.d.update(it)
 
     def __iter__(self) -> Iterator[KT]:
@@ -94,7 +94,7 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
         close(self.d)
 
 
-def funcname(func) -> str:
+def funcname(func: Callable) -> str:
     """Get the name of a function."""
     while hasattr(func, "func"):
         func = func.func

--- a/zict/lru.py
+++ b/zict/lru.py
@@ -80,9 +80,9 @@ class LRU(ZictBase[KT, VT]):
         except KeyError:
             pass
 
-        weight = self.weight(key, value)  # type: ignore
+        weight = self.weight(key, value)
 
-        def set_():
+        def set_() -> None:
             self.d[key] = value
             self.order[key] = None
             self.weights[key] = weight

--- a/zict/sieve.py
+++ b/zict/sieve.py
@@ -55,7 +55,7 @@ class Sieve(ZictBase[KT, VT], Generic[KT, VT, MKT]):
 
     def __setitem__(self, key: KT, value: VT) -> None:
         old_mapping = self.key_to_mapping.get(key)
-        mkey = self.selector(key, value)  # type: ignore
+        mkey = self.selector(key, value)
         mapping = self.mappings[mkey]
         if old_mapping is not None and old_mapping is not mapping:
             del old_mapping[key]
@@ -73,7 +73,7 @@ class Sieve(ZictBase[KT, VT], Generic[KT, VT, MKT]):
 
         for key, value in items:
             old_mapping = self.key_to_mapping.get(key)
-            mkey = self.selector(key, value)  # type: ignore
+            mkey = self.selector(key, value)
             mapping = self.mappings[mkey]
             if old_mapping is not None and old_mapping is not mapping:
                 del old_mapping[key]

--- a/zict/tests/test_buffer.py
+++ b/zict/tests/test_buffer.py
@@ -1,13 +1,13 @@
 import pytest
 
-import zict
+from zict import Buffer
 from zict.tests import utils_test
 
 
 def test_simple():
-    a = dict()
-    b = dict()
-    buff = zict.Buffer(a, b, n=10, weight=lambda k, v: v)
+    a = {}
+    b = {}
+    buff = Buffer(a, b, n=10, weight=lambda k, v: v)
 
     buff["x"] = 1
     buff["y"] = 2
@@ -64,10 +64,9 @@ def test_simple():
 
 
 def test_setitem_avoid_fast_slow_duplicate():
-
-    a = dict()
-    b = dict()
-    buff = zict.Buffer(a, b, n=10, weight=lambda k, v: v)
+    a = {}
+    b = {}
+    buff = Buffer(a, b, n=10, weight=lambda k, v: v)
     for first, second in [(1, 12), (12, 1)]:
         buff["a"] = first
         assert buff["a"] == first
@@ -91,7 +90,7 @@ def test_mapping():
     """
     a = {}
     b = {}
-    buff = zict.Buffer(a, b, n=2)
+    buff = Buffer(a, b, n=2)
     utils_test.check_mapping(buff)
     utils_test.check_closing(buff)
 
@@ -107,9 +106,9 @@ def test_callbacks():
     def s2f_cb(k, v):
         s2f.append(k)
 
-    a = dict()
-    b = dict()
-    buff = zict.Buffer(
+    a = {}
+    b = {}
+    buff = Buffer(
         a,
         b,
         n=10,
@@ -158,7 +157,7 @@ def test_callbacks_exception_catch():
 
     a = {}
     b = {}
-    buff = zict.Buffer(
+    buff = Buffer(
         a,
         b,
         n=10,

--- a/zict/tests/test_cache.py
+++ b/zict/tests/test_cache.py
@@ -3,7 +3,7 @@ from collections import UserDict
 
 import pytest
 
-from zict.cache import Cache, WeakValueMapping
+from zict import Cache, WeakValueMapping
 
 
 def test_cache_get_set_del():

--- a/zict/tests/test_file.py
+++ b/zict/tests/test_file.py
@@ -3,7 +3,7 @@ import pathlib
 
 import pytest
 
-from zict.file import File
+from zict import File
 from zict.tests import utils_test
 
 

--- a/zict/tests/test_func.py
+++ b/zict/tests/test_func.py
@@ -25,7 +25,7 @@ def rotr(x):
 
 
 def test_simple():
-    d = dict()
+    d = {}
     f = Func(inc, dec, d)
     f["x"] = 10
     assert f["x"] == 10

--- a/zict/tests/test_lmdb.py
+++ b/zict/tests/test_lmdb.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from zict.lmdb import LMDB
+from zict import LMDB
 from zict.tests import utils_test
 
 pytest.importorskip("lmdb")

--- a/zict/zip.py
+++ b/zict/zip.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import zipfile
 from collections.abc import Iterator
 from typing import MutableMapping  # TODO move to collections.abc (needs Python >=3.9)
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     # TODO: move to typing on Python 3.8+ and 3.10+ respectively
@@ -87,5 +87,5 @@ class Zip(MutableMapping[str, bytes]):
     def __enter__(self) -> Zip:
         return self
 
-    def __exit__(self, type, value, traceback) -> None:
+    def __exit__(self, *args: Any) -> None:
         self.close()


### PR DESCRIPTION
- In the rendered documentation as well as in the `objects.inv` file for intersphinx, hide implementation modules; e.g. change from `zict.buffer.Buffer` to `zict.Buffer`.

- Tighten mypy validation, bringing it in line with dask/distributed