### PR TITLE
Partial thread-safety

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,6 +12,8 @@ Changelog
   (:pr:`78`) `Guido Imperiale`_
 - ``LMDB`` now uses memory-mapped I/O on MacOSX and is usable on Windows.
   (:pr:`78`) `Guido Imperiale`_
+- The library is now partially thread-safe.
+  (:pr:`82`) `Guido Imperiale`_
 
 
 2.2.0 - 2022-04-28

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,7 +15,6 @@ to form intuitive interfaces over complex storage systems policies.
 
 Example
 -------
-
 In the following example we create an LRU dictionary backed by pickle-encoded,
 zlib-compressed, directory of files.
 
@@ -35,9 +34,13 @@ zlib-compressed, directory of files.
    >>> d['x']
    [1, 2, 3]
 
+Thread-safety
+-------------
+This library is only partially thread-safe. Refer to the documentation of the individual
+mappings for details.
+
 API
 ---
-
 .. currentmodule:: zict
 
 .. autoclass:: Buffer
@@ -62,5 +65,4 @@ API
 
 Changelog
 ---------
-
 Release notes can be found :doc:`here <changelog>`.

--- a/zict/file.py
+++ b/zict/file.py
@@ -40,6 +40,11 @@ class File(ZictBase[str, bytes]):
     memmap: bool (optional)
         If True, use `mmap` for reading. Defaults to False.
 
+    Notes
+    -----
+    ``__contains__`` and ``__len__`` are thread-safe.
+    All other methods are not thread-safe.
+
     Examples
     --------
     >>> z = File('myfile')  # doctest: +SKIP
@@ -127,10 +132,8 @@ class File(ZictBase[str, bytes]):
         return iter(self._keys)
 
     def __delitem__(self, key: str) -> None:
-        if key not in self._keys:
-            raise KeyError(key)
-        os.remove(os.path.join(self.directory, _safe_key(key)))
         self._keys.remove(key)
+        os.remove(os.path.join(self.directory, _safe_key(key)))
 
     def __len__(self) -> int:
         return len(self._keys)

--- a/zict/func.py
+++ b/zict/func.py
@@ -19,6 +19,15 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
         Function to call on value as we pull it from the mapping
     d: MutableMapping
 
+    Notes
+    -----
+    ``__contains__, ``__delitem__``, and ``__len__`` are thread-safe if the same methods
+    on ``d`` are thread-safe.
+    ``__setitem__`` and ``update`` are thread-safe if the same methods on ``d`` as well
+    ``dump`` are thread-safe.
+    ``__getitem__`` is thread-safe if both ``d.__getitem__`` and ``load`` are
+    thread-safe.
+
     Examples
     --------
     >>> def double(x):

--- a/zict/lmdb.py
+++ b/zict/lmdb.py
@@ -30,6 +30,11 @@ class LMDB(ZictBase[str, bytes]):
         On Windows, preallocated total size of the database file on disk. Defaults to
         10 MiB to encourage explicitly setting it.
 
+    Notes
+    -----
+    None of this class is thread-safe - not even normally trivial methods such as
+    ``__len__ `` or ``__contains__``.
+
     Examples
     --------
     >>> z = LMDB('/tmp/somedir/')  # doctest: +SKIP

--- a/zict/sieve.py
+++ b/zict/sieve.py
@@ -23,13 +23,19 @@ class Sieve(ZictBase[KT, VT], Generic[KT, VT, MKT]):
     mappings: dict of {mapping key: MutableMapping}
     selector: callable (key, value) -> mapping key
 
+    Notes
+    -----
+    ``__contains__`` is thread-safe.
+    ``__len__`` is thread-safe if the same method on all mappings is thread-safe.
+    All other methods are not thread-safe.
+
     Examples
     --------
     >>> small = {}
     >>> large = DataBase()                        # doctest: +SKIP
     >>> mappings = {True: small, False: large}    # doctest: +SKIP
     >>> def is_small(key, value):                 # doctest: +SKIP
-            return sys.getsizeof(value) < 10000
+    ...     return sys.getsizeof(value) < 10000   # doctest: +SKIP
     >>> d = Sieve(mappings, is_small)             # doctest: +SKIP
 
     See Also

--- a/zict/tests/test_lru.py
+++ b/zict/tests/test_lru.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from multiprocessing import cpu_count
+from threading import Barrier
 
 import pytest
 
@@ -249,9 +249,11 @@ def test_getitem_is_threasafe():
     lru["x"] = 1
 
     def f(_):
-        return lru["x"]
+        barrier.wait()
+        for _ in range(5_000_000):
+            assert lru["x"] == 1
 
-    n = cpu_count()
-    with ThreadPoolExecutor(n) as ex:
-        for out in ex.map(f, range(100_000)):
-            assert out == 1
+    barrier = Barrier(2)
+    with ThreadPoolExecutor(2) as ex:
+        for _ in ex.map(f, range(2)):
+            pass

--- a/zict/tests/test_lru.py
+++ b/zict/tests/test_lru.py
@@ -1,3 +1,6 @@
+from concurrent.futures import ThreadPoolExecutor
+from multiprocessing import cpu_count
+
 import pytest
 
 from zict import LRU
@@ -236,3 +239,19 @@ def test_init_not_empty():
     assert lru1.weights == lru2.weights == {2: 40, 3: 60}
     assert lru1.total_weight == lru2.total_weight == 100
     assert list(lru1.order) == list(lru2.order) == [2, 3]
+
+
+def test_getitem_is_threasafe():
+    """Note: even if you maliciously tamper with LRU.__getitem__ to make it
+    thread-unsafe, this test fails only ~20% of the times on a 12-CPU desktop.
+    """
+    lru = LRU(100, {})
+    lru["x"] = 1
+
+    def f(_):
+        return lru["x"]
+
+    n = cpu_count()
+    with ThreadPoolExecutor(n) as ex:
+        for out in ex.map(f, range(100_000)):
+            assert out == 1

--- a/zict/zip.py
+++ b/zict/zip.py
@@ -22,6 +22,11 @@ class Zip(MutableMapping[str, bytes]):
     filename: string
     mode: string, ('r', 'w', 'a'), defaults to 'a'
 
+    Notes
+    -----
+    None of this class is thread-safe - not even normally trivial methods such as
+    ``__len__ `` or ``__contains__``.
+
     Examples
     --------
     >>> z = Zip('myfile.zip')  # doctest: +SKIP


### PR DESCRIPTION
- Partially closes https://github.com/dask/distributed/issues/4424

Make the library partially thread-safe.
Crucially, this makes `distributed.Worker.data.fast.__getitem__()` thread-safe, which means that `Worker.execute` and `get_data` will only need to offload to a thread if any of the keys are actually spilled.

Actual thread-offloadling mechanics will be in later PRs (both here and in distributed).