### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: windows-latest
-            python-version: "3.7"
+            python-version: "3.8"
           - os: windows-latest
             python-version: "3.11"
           - os: macos-latest
-            python-version: "3.7"
+            python-version: "3.8"
           - os: macos-latest
             python-version: "3.11"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,14 +14,14 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py37-plus
+          - --py38-plus
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
       - id: black
         language_version: python3
         args:
-          - --target-version=py37
+          - --target-version=py38
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 
 2.3.0 - Unreleased
 ------------------
+- Dropped support for Python 3.7 (:pr:`84`) `Guido Imperiale`_
 - ``File.__getitem__`` now returns bytearray instead of bytes. This prevents a memcpy
   when deserializing numpy arrays with dask. (:pr:`74`) `Guido Imperiale`_
 - Removed dependency from ``heapdict``; sped up ``LRU``. (:pr:`77`) `Guido Imperiale`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -76,7 +75,7 @@ known_first_party = zict
 
 
 [mypy]
-# Silence errors about Python 3.9-style delayed type annotations on Python 3.7/3.8
+# Silence errors about Python 3.9-style delayed type annotations on Python 3.8
 python_version = 3.9
 # See https://github.com/python/mypy/issues/12286 for automatic multi-platform support
 platform = linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 packages = zict
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
 
 [options.package_data]

--- a/zict/cache.py
+++ b/zict/cache.py
@@ -93,7 +93,7 @@ class Cache(ZictBase[KT, VT]):
 
 
 if TYPE_CHECKING:
-    # TODO Python 3.9: remove this branch and just use [] in the implementation below
+    # TODO remove this branch and just use [] in the implementation below (needs Python >=3.9)
     class WeakValueMapping(weakref.WeakValueDictionary[KT, VT]):
         ...
 

--- a/zict/tests/test_common.py
+++ b/zict/tests/test_common.py
@@ -1,0 +1,53 @@
+from collections import UserDict
+
+from zict.common import ZictBase
+
+
+def test_close_on_del():
+    closed = False
+
+    class D(ZictBase, UserDict):
+        def close(self):
+            nonlocal closed
+            closed = True
+
+    d = D()
+    del d
+    assert closed
+
+
+def test_context():
+    closed = False
+
+    class D(ZictBase, UserDict):
+        def close(self):
+            nonlocal closed
+            closed = True
+
+    d = D()
+    with d as d2:
+        assert d2 is d
+    assert closed
+
+
+def test_update():
+    items = []
+
+    class D(ZictBase, UserDict):
+        def _do_update(self, items_):
+            nonlocal items
+            items = items_
+
+    d = D()
+    d.update({"x": 1})
+    assert list(items) == [("x", 1)]
+    d.update(iter([("x", 2)]))
+    assert list(items) == [("x", 2)]
+    d.update({"x": 3}, y=4)
+    assert list(items) == [("x", 3), ("y", 4)]
+    d.update(x=5)
+    assert list(items) == [("x", 5)]
+
+    # Special kwargs can't overwrite positional-only parameters
+    d.update(self=1, other=2)
+    assert list(items) == [("self", 1), ("other", 2)]

--- a/zict/zip.py
+++ b/zict/zip.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import zipfile
 from collections.abc import Iterator
 from typing import MutableMapping  # TODO move to collections.abc (needs Python >=3.9)
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    # TODO: move to typing on Python 3.8+ and 3.10+ respectively
-    from typing_extensions import Literal, TypeAlias
+    # TODO: import from typing (needs Python >=3.10)
+    from typing_extensions import TypeAlias
 
-    FileMode: TypeAlias = Literal["r", "w", "x", "a"]
+FileMode: TypeAlias = Literal["r", "w", "x", "a"]
 
 
 class Zip(MutableMapping[str, bytes]):


### PR DESCRIPTION
- Drop support for Python 3.7
- Automatically call close() on dereferencing
- Add unit tests for update() and close()