### PR TITLE
Enhanced thread-safety in zict.File

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -14,7 +14,7 @@ Changelog
 - ``LMDB`` now uses memory-mapped I/O on MacOSX and is usable on Windows.
   (:pr:`78`) `Guido Imperiale`_
 - The library is now partially thread-safe.
-  (:pr:`82`) `Guido Imperiale`_
+  (:pr:`82`, :pr:`90`) `Guido Imperiale`_
 
 
 2.2.0 - 2022-04-28


### PR DESCRIPTION
- Partially closes dask/distributed#4424
- Blocked by https://github.com/dask/distributed/pull/7691

`zict.File` is now almost fully thread-safe, with the only caveat that you can't call `__setitem__` on the same key at the same time from two different threads. Crucially for dask/distributed#4424, you can now delete a key from the main thread while the same key is being either read or written from an offloaded thread.