### PR TITLE
Misc CI tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,11 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          condarc-file: continuous_integration/condarc
           use-mamba: true
           activate-environment: test
+          condarc-file: continuous_integration/condarc
           python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        shell: bash -l {0}
-        run: mamba install pytest python-lmdb psutil
+          environment-file: continuous_integration/environment.yml
 
       - name: Install zict
         shell: bash -l {0}

--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -7,7 +7,5 @@ dependencies:
   - psutil
   - python-lmdb
   - pytest
-  - pytest-faulthandler
   - pytest-repeat
-  - pytest-rerunfailures
   - pytest-timeout

--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -1,0 +1,13 @@
+name: test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pip
+  - psutil
+  - python-lmdb
+  - pytest
+  - pytest-faulthandler
+  - pytest-repeat
+  - pytest-rerunfailures
+  - pytest-timeout

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,21 @@ ignore =
 max-line-length = 88
 
 [tool:pytest]
-addopts = -v --doctest-modules
+addopts =
+    -v
+    --doctest-modules
+    --durations=20
+    --strict-markers
+    --strict-config
+
+# pytest-timeout settings
+# 'thread' kills off the whole test suite. 'signal' only kills the offending test.
+# However, 'signal' doesn't work on Windows (due to lack of SIGALRM).
+timeout_method = thread
+# This should not be reduced; Windows CI has been observed to be occasionally
+# exceptionally slow.
+timeout = 300
+
 
 [isort]
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
- Use conda environment file
- Add support for `@pytest.mark.repeat`
- Add support for `@pytest.mark.timeout` and set default timeout on all tests
- ~~Add support for `@pytest.mark.xfail` (currently unused)~~
- ~~Add support for `@pytest.mark.flaky` (currently unused)~~