### PR TITLE
Lock-based thread safety

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -14,10 +14,10 @@ Changelog
   (:pr:`78`) `Guido Imperiale`_
 - ``LMDB`` now uses memory-mapped I/O on MacOSX and is usable on Windows.
   (:pr:`78`) `Guido Imperiale`_
-- The library is now partially thread-safe.
-  (:pr:`82`, :pr:`90`, :pr:`93`) `Guido Imperiale`_
+- The library is now almost completely thread-safe.
+  (:pr:`82`, :pr:`90`, :pr:`92`, :pr:`93`) `Guido Imperiale`_
 - :class:`LRU` and :class:`Buffer` now support delayed eviction.
-  New objects :class:`Accumulator` and :class:`InsertionSortedSet`.
+  New object :class:`InsertionSortedSet`.
   (:pr:`87`) `Guido Imperiale`_
 - All mappings now return proper KeysView, ItemsView, and ValuesView objects from their
   keys(), items(), and values() methods (:pr:`93`) `Guido Imperiale`_

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -36,8 +36,8 @@ zlib-compressed, directory of files.
 
 Thread-safety
 -------------
-This library is only partially thread-safe. Refer to the documentation of the individual
-mappings for details.
+Most classes in this library are thread-safe.
+Refer to the documentation of the individual mappings for exceptions.
 
 API
 ---
@@ -64,8 +64,6 @@ API
 
 Additionally, **zict** makes available the following general-purpose objects:
 
-.. autoclass:: Accumulator
-   :members:
 .. autoclass:: InsertionSortedSet
    :members:
 .. autoclass:: WeakValueMapping

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,9 +75,9 @@ addopts =
 # 'thread' kills off the whole test suite. 'signal' only kills the offending test.
 # However, 'signal' doesn't work on Windows (due to lack of SIGALRM).
 timeout_method = thread
-# This should not be reduced; Windows CI has been observed to be occasionally
-# exceptionally slow.
-timeout = 300
+timeout = 180
+markers =
+    stress: slow-running stress test with a random component. Pass --stress <n> to change number of reruns.
 
 
 [isort]

--- a/zict/__init__.py
+++ b/zict/__init__.py
@@ -6,7 +6,6 @@ from zict.func import Func as Func
 from zict.lmdb import LMDB as LMDB
 from zict.lru import LRU as LRU
 from zict.sieve import Sieve as Sieve
-from zict.utils import Accumulator as Accumulator
 from zict.utils import InsertionSortedSet as InsertionSortedSet
 from zict.zip import Zip as Zip
 

--- a/zict/buffer.py
+++ b/zict/buffer.py
@@ -7,7 +7,7 @@ from typing import (  # TODO import from collections.abc (needs Python >=3.9)
     ValuesView,
 )
 
-from zict.common import KT, VT, ZictBase, close, flush
+from zict.common import KT, VT, ZictBase, close, discard, flush, locked
 from zict.lru import LRU
 
 
@@ -37,8 +37,10 @@ class Buffer(ZictBase[KT, VT]):
 
     Notes
     -----
-    ``__contains__`` and ``__len__`` are thread-safe if the same methods on both
-    ``fast`` and ``slow`` are thread-safe. All other methods are not thread-safe.
+    If you call methods of this class from multiple threads, access will be fast as long
+    as all methods of ``fast``, plus ``slow.__contains__`` and ``slow.__delitem__``, are
+    fast. ``slow.__getitem__``, ``slow.__setitem__`` and callbacks are not protected
+    by locks.
 
     Examples
     --------
@@ -58,6 +60,7 @@ class Buffer(ZictBase[KT, VT]):
     weight: Callable[[KT, VT], float]
     fast_to_slow_callbacks: list[Callable[[KT, VT], None]]
     slow_to_fast_callbacks: list[Callable[[KT, VT], None]]
+    _cancel_restore: dict[KT, bool]
 
     def __init__(
         self,
@@ -72,7 +75,14 @@ class Buffer(ZictBase[KT, VT]):
         | list[Callable[[KT, VT], None]]
         | None = None,
     ):
-        self.fast = LRU(n, fast, weight=weight, on_evict=[self.fast_to_slow])
+        super().__init__()
+        self.fast = LRU(
+            n,
+            fast,
+            weight=weight,
+            on_evict=[self.fast_to_slow],
+            on_cancel_evict=[self._cancel_evict],
+        )
         self.slow = slow
         self.weight = weight
         if callable(fast_to_slow_callbacks):
@@ -81,6 +91,7 @@ class Buffer(ZictBase[KT, VT]):
             slow_to_fast_callbacks = [slow_to_fast_callbacks]
         self.fast_to_slow_callbacks = fast_to_slow_callbacks or []
         self.slow_to_fast_callbacks = slow_to_fast_callbacks or []
+        self._cancel_restore = {}
 
     @property
     def n(self) -> float:
@@ -98,16 +109,38 @@ class Buffer(ZictBase[KT, VT]):
             raise
 
     def slow_to_fast(self, key: KT) -> VT:
-        value = self.slow[key]
+        self._cancel_restore[key] = False
+        try:
+            with self.unlock():
+                value = self.slow[key]
+            if self._cancel_restore[key]:
+                raise KeyError(key)
+        finally:
+            del self._cancel_restore[key]
+
         # Avoid useless movement for heavy values
         w = self.weight(key, value)
         if w <= self.n:
+            # Multithreaded edge case:
+            # - Thread 1 starts slow_to_fast(x) and puts it at the top of fast
+            # - This causes the eviction of older key(s)
+            # - While thread 1 is evicting older keys, thread 2 is loading fast with
+            #   set_noevict()
+            # - By the time the eviction of the older key(s) is done, there is
+            #   enough weight in fast that thread 1 will spill x
+            # - If the below code was just `self.fast[key] = value; del
+            #   self.slow[key]` now the key would be in neither slow nor fast!
+            self.fast.set_noevict(key, value)
             del self.slow[key]
-            self.fast[key] = value
-        for cb in self.slow_to_fast_callbacks:
-            cb(key, value)
+
+        with self.unlock():
+            self.fast.evict_until_below_target()
+            for cb in self.slow_to_fast_callbacks:
+                cb(key, value)
+
         return value
 
+    @locked
     def __getitem__(self, key: KT) -> VT:
         try:
             return self.fast[key]
@@ -115,30 +148,40 @@ class Buffer(ZictBase[KT, VT]):
             return self.slow_to_fast(key)
 
     def __setitem__(self, key: KT, value: VT) -> None:
-        try:
-            del self.slow[key]
-        except KeyError:
-            pass
-        # This may trigger an eviction from fast to slow of older keys.
-        # If the weight is individually greater than n, then key/value will be stored
-        # into self.slow instead (see LRU.__setitem__).
+        with self.lock:
+            discard(self.slow, key)
+            if key in self._cancel_restore:
+                self._cancel_restore[key] = True
         self.fast[key] = value
 
+    @locked
     def set_noevict(self, key: KT, value: VT) -> None:
         """Variant of ``__setitem__`` that does not move keys from fast to slow if the
         total weight exceeds n
         """
-        try:
-            del self.slow[key]
-        except KeyError:
-            pass
+        discard(self.slow, key)
+        if key in self._cancel_restore:
+            self._cancel_restore[key] = True
         self.fast.set_noevict(key, value)
 
+    def evict_until_below_target(self, n: float | None = None) -> None:
+        """Wrapper around :meth:`zict.LRU.evict_until_below_target`.
+        Presented here to allow easier overriding.
+        """
+        self.fast.evict_until_below_target(n)
+
+    @locked
     def __delitem__(self, key: KT) -> None:
+        if key in self._cancel_restore:
+            self._cancel_restore[key] = True
         try:
             del self.fast[key]
         except KeyError:
             del self.slow[key]
+
+    @locked
+    def _cancel_evict(self, key: KT, value: VT) -> None:
+        discard(self.slow, key)
 
     def values(self) -> ValuesView[VT]:
         return BufferValuesView(self)
@@ -147,7 +190,15 @@ class Buffer(ZictBase[KT, VT]):
         return BufferItemsView(self)
 
     def __len__(self) -> int:
-        return len(self.fast) + len(self.slow)
+        with self.lock, self.fast.lock:
+            return (
+                len(self.fast)
+                + len(self.slow)
+                - sum(
+                    k in self.fast and k in self.slow
+                    for k in chain(self._cancel_restore, self.fast._cancel_evict)
+                )
+            )
 
     def __iter__(self) -> Iterator[KT]:
         """Make sure that the iteration is not disrupted if you evict/restore a key in

--- a/zict/common.py
+++ b/zict/common.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+import threading
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import contextmanager
 from enum import Enum
+from functools import wraps
 from itertools import chain
 from typing import MutableMapping  # TODO move to collections.abc (needs Python >=3.9)
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 T = TypeVar("T")
 KT = TypeVar("KT")
 VT = TypeVar("VT")
 
 if TYPE_CHECKING:
-    # TODO import from typing (needs Python >=3.11)
-    from typing_extensions import Self
+    # TODO import ParamSpec from typing (needs Python >=3.10)
+    # TODO import Self from typing (needs Python >=3.11)
+    from typing_extensions import ParamSpec, Self
+
+    P = ParamSpec("P")
 
 
 class NoDefault(Enum):
@@ -24,6 +30,20 @@ nodefault = NoDefault.nodefault
 
 class ZictBase(MutableMapping[KT, VT]):
     """Base class for zict mappings"""
+
+    lock: threading.RLock
+
+    def __init__(self) -> None:
+        self.lock = threading.RLock()
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        del state["lock"]
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__ = state
+        self.lock = threading.RLock()
 
     def update(  # type: ignore[override]
         self,
@@ -41,6 +61,12 @@ class ZictBase(MutableMapping[KT, VT]):
         for k, v in items:
             self[k] = v
 
+    def discard(self, key: KT) -> None:
+        """Flush *key* if possible.
+        Not the same as ``m.pop(key, None)``, as it doesn't trigger ``__getitem__``.
+        """
+        discard(self, key)
+
     def close(self) -> None:
         """Release any system resources held by this object"""
 
@@ -52,6 +78,17 @@ class ZictBase(MutableMapping[KT, VT]):
 
     def __del__(self) -> None:
         self.close()
+
+    @contextmanager
+    def unlock(self) -> Iterator[None]:
+        """To be used in a method decorated by ``@locked``.
+        Temporarily releases the mapping's RLock.
+        """
+        self.lock.release()
+        try:
+            yield
+        finally:
+            self.lock.acquire()
 
 
 def close(*z: Any) -> None:
@@ -66,3 +103,27 @@ def flush(*z: Any) -> None:
     for zi in z:
         if hasattr(zi, "flush"):
             zi.flush()
+
+
+def discard(m: MutableMapping[KT, VT], key: KT) -> None:
+    """Flush *key* if possible.
+    Not the same as ``m.pop(key, None)``, as it doesn't trigger ``__getitem__``.
+    """
+    try:
+        del m[key]
+    except KeyError:
+        pass
+
+
+def locked(func: Callable[P, VT]) -> Callable[P, VT]:
+    """Decorator for a method of ZictBase, which wraps the whole method in a
+    mapping-global rlock.
+    """
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> VT:
+        self = cast(ZictBase, args[0])
+        with self.lock:
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/zict/func.py
+++ b/zict/func.py
@@ -19,15 +19,6 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
         Function to call on value as we pull it from the mapping
     d: MutableMapping
 
-    Notes
-    -----
-    ``__contains__, ``__delitem__``, and ``__len__`` are thread-safe if the same methods
-    on ``d`` are thread-safe.
-    ``__setitem__`` and ``update`` are thread-safe if the same methods on ``d`` as well
-    ``dump`` are thread-safe.
-    ``__getitem__`` is thread-safe if both ``d.__getitem__`` and ``load`` are
-    thread-safe.
-
     Examples
     --------
     >>> def double(x):
@@ -55,6 +46,7 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
         load: Callable[[WT], VT],
         d: MutableMapping[KT, WT],
     ):
+        super().__init__()
         self.dump = dump
         self.load = load
         self.d = d

--- a/zict/lmdb.py
+++ b/zict/lmdb.py
@@ -50,6 +50,7 @@ class LMDB(ZictBase[str, bytes]):
     def __init__(self, directory: str | pathlib.Path, map_size: int | None = None):
         import lmdb
 
+        super().__init__()
         if map_size is None:
             if sys.platform != "win32":
                 map_size = min(2**40, sys.maxsize // 4)

--- a/zict/tests/conftest.py
+++ b/zict/tests/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+
+@pytest.fixture
+def is_locked():
+    """Callable that returns True if the parameter zict mapping has its RLock engaged"""
+    with ThreadPoolExecutor(1) as ex:
+
+        def __is_locked(d):
+            out = d.lock.acquire(blocking=False)
+            if out:
+                d.lock.release()
+            return not out
+
+        def _is_locked(d):
+            return ex.submit(__is_locked, d).result()
+
+        yield _is_locked

--- a/zict/tests/test_cache.py
+++ b/zict/tests/test_cache.py
@@ -1,5 +1,7 @@
 import gc
+import threading
 from collections import UserDict
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -139,3 +141,271 @@ def test_mapping():
     buff = Cache({}, {})
     utils_test.check_mapping(buff)
     utils_test.check_closing(buff)
+
+    buff.clear()
+    assert not buff.cache
+    assert not buff.data
+    assert not buff._last_updated
+
+
+@pytest.mark.parametrize("get_when", ("before", "after"))
+@pytest.mark.parametrize("set_when", ("before", "after"))
+@pytest.mark.parametrize(
+    "starts_first,seed,update_on_set",
+    [
+        ("get", True, False),
+        ("set", False, False),
+        ("set", False, True),
+        ("set", True, False),
+        ("set", True, True),
+    ],
+)
+@pytest.mark.parametrize("ends_first", ("get", "set"))
+def test_multithread_race_condition_set_get(
+    get_when, set_when, starts_first, seed, update_on_set, ends_first
+):
+    """Test race conditions between __setitem__ and __getitem__ on the same key"""
+    in_get = threading.Event()
+    block_get = threading.Event()
+    in_set = threading.Event()
+    block_set = threading.Event()
+
+    class Slow(UserDict):
+        def __getitem__(self, k):
+            if get_when == "before":
+                try:
+                    v = self.data[k]
+                finally:
+                    in_get.set()
+                assert block_get.wait(timeout=5)
+                return v
+            else:
+                in_get.set()
+                assert block_get.wait(timeout=5)
+                return self.data[k]
+
+        def __setitem__(self, k, v):
+            if set_when == "before":
+                self.data[k] = v
+                in_set.set()
+                assert block_set.wait(timeout=5)
+            else:
+                in_set.set()
+                assert block_set.wait(timeout=5)
+                self.data[k] = v
+
+    z = Cache(Slow(), {}, update_on_set=update_on_set)
+    if seed:
+        block_set.set()
+        z["x"] = 1
+        in_set.clear()
+        block_set.clear()
+        assert z.data.data == {"x": 1}
+        assert set(z._last_updated) == {"x"}
+        if update_on_set:
+            assert z.cache == {"x": 1}
+        else:
+            assert z.cache == {}
+
+    with ThreadPoolExecutor(2) as ex:
+        if starts_first == "get":
+            get_fut = ex.submit(z.__getitem__, "x")
+            assert in_get.wait(timeout=5)
+            set_fut = ex.submit(z.__setitem__, "x", 2)
+            assert in_set.wait(timeout=5)
+        else:
+            set_fut = ex.submit(z.__setitem__, "x", 2)
+            assert in_set.wait(timeout=5)
+            get_fut = ex.submit(z.__getitem__, "x")
+            assert in_get.wait(timeout=5)
+
+        if ends_first == "get":
+            block_get.set()
+            try:
+                assert get_fut.result() in (1, 2)
+            except KeyError:
+                pass
+            block_set.set()
+            set_fut.result()
+        else:
+            block_set.set()
+            set_fut.result()
+            block_get.set()
+            try:
+                assert get_fut.result() in (1, 2)
+            except KeyError:
+                pass
+
+    assert z.data.data == {"x": 2}
+    # The cache is either not populated or up to date
+    assert z.cache in ({}, {"x": 2})
+    assert set(z._last_updated) == {"x"}
+
+
+@pytest.mark.parametrize("get_when", ("before", "after"))
+def test_multithread_race_condition_del_get(get_when):
+    """Test race conditions between __delitem__ and __getitem__ on the same key"""
+    in_get = threading.Event()
+    block_get = threading.Event()
+
+    class Slow(UserDict):
+        def __getitem__(self, k):
+            if get_when == "before":
+                v = self.data[k]
+                in_get.set()
+                assert block_get.wait(timeout=5)
+                return v
+            else:
+                in_get.set()
+                assert block_get.wait(timeout=5)
+                return self.data[k]
+
+    z = Cache(Slow(), {}, update_on_set=False)
+    z["x"] = 1
+    assert z.data.data == {"x": 1}
+    assert set(z._last_updated) == {"x"}
+    assert z.cache == {}
+
+    with ThreadPoolExecutor(1) as ex:
+        get_fut = ex.submit(z.__getitem__, "x")
+        assert in_get.wait(timeout=5)
+        del z["x"]
+
+        block_get.set()
+        if get_when == "before":
+            assert get_fut.result() == 1
+        else:
+            with pytest.raises(KeyError):
+                get_fut.result()
+
+    assert not z.data.data
+    assert not z.cache
+    assert not z._last_updated
+
+
+@pytest.mark.parametrize("set_when", ("before", "after"))
+@pytest.mark.parametrize(
+    "seed_data,seed_cache", [(False, False), (True, False), (True, True)]
+)
+@pytest.mark.parametrize("update_on_set", [False, True])
+def test_multithread_race_condition_del_set(
+    set_when, seed_data, seed_cache, update_on_set
+):
+    """Test race conditions between __delitem__ and __setitem__ on the same key"""
+    in_set = threading.Event()
+    block_set = threading.Event()
+
+    class Slow(UserDict):
+        def __setitem__(self, k, v):
+            if set_when == "before":
+                self.data[k] = v
+                in_set.set()
+                assert block_set.wait(timeout=5)
+            else:
+                in_set.set()
+                assert block_set.wait(timeout=5)
+                self.data[k] = v
+
+    z = Cache(Slow(), {}, update_on_set=update_on_set)
+    if seed_data:
+        block_set.set()
+        z["x"] = 1
+        in_set.clear()
+        block_set.clear()
+        if seed_cache and not update_on_set:
+            _ = z["x"]
+
+    with ThreadPoolExecutor(1) as ex:
+        set_fut = ex.submit(z.__setitem__, "x", 2)
+        assert in_set.wait(timeout=5)
+        try:
+            del z["x"]
+        except KeyError:
+            pass
+        block_set.set()
+        set_fut.result()
+
+    assert z.data.data in ({"x": 2}, {})
+    assert z.cache in (z.data.data, {})
+    assert z._last_updated.keys() == z.data.data.keys()
+
+
+@pytest.mark.parametrize("set1_when", ("before", "after"))
+@pytest.mark.parametrize("set2_when", ("before", "after"))
+@pytest.mark.parametrize("starts_first", (1, 2))
+@pytest.mark.parametrize("ends_first", (1, 2))
+@pytest.mark.parametrize(
+    "seed_data,seed_cache", [(False, False), (True, False), (True, True)]
+)
+@pytest.mark.parametrize("update_on_set", [False, True])
+def test_multithread_race_condition_set_set(
+    set1_when, set2_when, starts_first, ends_first, seed_data, seed_cache, update_on_set
+):
+    """Test __setitem__ in race condition with itself"""
+    when = {1: set1_when, 2: set2_when}
+    in_set = {1: threading.Event(), 2: threading.Event()}
+    block_set = {1: threading.Event(), 2: threading.Event()}
+
+    class Slow(UserDict):
+        def __setitem__(self, k, v):
+            if v == 0:
+                # seed
+                self.data[k] = v
+                return
+
+            if when[v] == "before":
+                self.data[k] = v
+                in_set[v].set()
+                assert block_set[v].wait(timeout=5)
+            else:
+                in_set[v].set()
+                assert block_set[v].wait(timeout=5)
+                self.data[k] = v
+
+    z = Cache(Slow(), {}, update_on_set=update_on_set)
+    if seed_data:
+        z["x"] = 0
+        if seed_cache and not update_on_set:
+            _ = z["x"]
+
+    with ThreadPoolExecutor(2) as ex:
+        futures = {}
+        futures[starts_first] = ex.submit(z.__setitem__, "x", starts_first)
+        assert in_set[starts_first].wait(timeout=5)
+        starts_second = 2 if starts_first == 1 else 1
+        futures[starts_second] = ex.submit(z.__setitem__, "x", starts_second)
+        assert in_set[starts_second].wait(timeout=5)
+
+        block_set[ends_first].set()
+        futures[ends_first].result()
+        ends_second = 2 if ends_first == 1 else 1
+        block_set[ends_second].set()
+        futures[ends_second].result()
+
+    assert z.data.data in ({"x": 1}, {"x": 2})
+    assert z.cache in (z.data.data, {})
+    assert set(z._last_updated) == {"x"}
+
+
+@pytest.mark.stress
+@pytest.mark.repeat(utils_test.REPEAT_STRESS_TESTS)
+@pytest.mark.parametrize("update_on_set", [False, True])
+def test_stress_different_keys_threadsafe(update_on_set):
+    buff = Cache(utils_test.SlowDict(0.001), {}, update_on_set=update_on_set)
+    utils_test.check_different_keys_threadsafe(buff)
+    assert not buff.cache
+    assert not buff.data
+    assert not buff._last_updated
+    utils_test.check_mapping(buff)
+
+
+@pytest.mark.stress
+@pytest.mark.repeat(utils_test.REPEAT_STRESS_TESTS)
+@pytest.mark.parametrize("update_on_set", [False, True])
+def test_stress_same_key_threadsafe(update_on_set):
+    buff = Cache(utils_test.SlowDict(0.001), {}, update_on_set=update_on_set)
+    utils_test.check_same_key_threadsafe(buff)
+    assert not buff.cache
+    assert not buff.data
+    assert not buff._last_updated
+    utils_test.check_mapping(buff)

--- a/zict/tests/test_sieve.py
+++ b/zict/tests/test_sieve.py
@@ -1,3 +1,10 @@
+import random
+import threading
+from collections import UserDict
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
 from zict import Sieve
 from zict.tests import utils_test
 
@@ -72,3 +79,146 @@ def test_mapping():
     z = Sieve(mappings, selector)
     utils_test.check_mapping(z)
     utils_test.check_closing(z)
+
+    z.clear()
+    assert z.mappings == {0: {}, 1: {}}
+    assert not z.key_to_mapping
+
+
+@pytest.mark.parametrize("method", ("__setitem__", "update"))
+@pytest.mark.parametrize("set_when", ("before", "after"))
+@pytest.mark.parametrize("seed", [False, "same", "different"])
+def test_multithread_race_condition_del_set(method, set_when, seed):
+    """Test race conditions between __delitem__ and __setitem__/update on the same key"""
+    in_set = threading.Event()
+    block_set = threading.Event()
+
+    class Slow(UserDict):
+        def __setitem__(self, k, v):
+            if set_when == "before":
+                self.data[k] = v
+                in_set.set()
+                assert block_set.wait(timeout=5)
+            else:
+                in_set.set()
+                assert block_set.wait(timeout=5)
+                self.data[k] = v
+
+    z = Sieve({0: {}, 1: Slow()}, selector=lambda k, v: v % 2)
+    if seed == "same":
+        block_set.set()
+        z["x"] = 1  # mapping 1
+        in_set.clear()
+        block_set.clear()
+    elif seed == "different":
+        z["x"] = 0  # mapping 0
+
+    with ThreadPoolExecutor(1) as ex:
+        if method == "__setitem__":
+            set_fut = ex.submit(z.__setitem__, "x", 3)  # mapping 1
+        else:
+            assert method == "update"
+            set_fut = ex.submit(z.update, {"x": 3})  # mapping 1
+        assert in_set.wait(timeout=5)
+        try:
+            del z["x"]
+        except KeyError:
+            pass
+        block_set.set()
+        set_fut.result()
+
+    assert not z.mappings[0]
+    assert not z.mappings[1]
+    assert not z.key_to_mapping
+
+
+@pytest.mark.parametrize("set1_when", ("before", "after"))
+@pytest.mark.parametrize("set2_when", ("before", "after"))
+@pytest.mark.parametrize("set1_method", ("__setitem__", "update"))
+@pytest.mark.parametrize("set2_method", ("__setitem__", "update"))
+@pytest.mark.parametrize("starts_first", (1, 2))
+@pytest.mark.parametrize("ends_first", (1, 2))
+@pytest.mark.parametrize("seed", [False, 0, 1, 2])
+def test_multithread_race_condition_set_set(
+    set1_when, set2_when, set1_method, set2_method, starts_first, ends_first, seed
+):
+    """Test __setitem__/update in race condition with __setitem__/update"""
+    when = {1: set1_when, 2: set2_when}
+    method = {1: set1_method, 2: set2_method}
+    in_set = {1: threading.Event(), 2: threading.Event()}
+    block_set = {1: threading.Event(), 2: threading.Event()}
+
+    class Slow(UserDict):
+        def __setitem__(self, k, v):
+            if v < 3:
+                # seed
+                self.data[k] = v
+                return
+            mkey = v % 3
+
+            if when[mkey] == "before":
+                self.data[k] = v
+                in_set[mkey].set()
+                assert block_set[mkey].wait(timeout=5)
+            else:
+                in_set[mkey].set()
+                assert block_set[mkey].wait(timeout=5)
+                self.data[k] = v
+
+    z = Sieve({0: {}, 1: Slow(), 2: Slow()}, selector=lambda k, v: v % 3)
+    if seed is not False:
+        z["x"] = seed
+
+    with ThreadPoolExecutor(2) as ex:
+        futures = {}
+        starts_second = 2 if starts_first == 1 else 1
+        for idx in (starts_first, starts_second):
+            if method[idx] == "__setitem__":
+                futures[idx] = ex.submit(z.__setitem__, "x", idx + 3)
+            else:
+                assert method[idx] == "update"
+                futures[idx] = ex.submit(z.update, {"x": idx + 3})
+            assert in_set[idx].wait(timeout=5)
+
+        block_set[ends_first].set()
+        futures[ends_first].result()
+        ends_second = 2 if ends_first == 1 else 1
+        block_set[ends_second].set()
+        futures[ends_second].result()
+
+    assert dict(z) in ({"x": 4}, {"x": 5})
+    assert z.mappings[0] == {}
+    if z["x"] == 4:
+        assert z.mappings[1] == {"x": 4}
+        assert z.mappings[2] == {}
+        assert z.key_to_mapping == {"x": z.mappings[1]}
+    else:
+        assert z.mappings[1] == {}
+        assert z.mappings[2] == {"x": 5}
+        assert z.key_to_mapping == {"x": z.mappings[2]}
+
+
+@pytest.mark.stress
+@pytest.mark.repeat(utils_test.REPEAT_STRESS_TESTS)
+def test_stress_different_keys_threadsafe():
+    a = {}
+    b = {}
+    z = Sieve({0: a, 1: b}, lambda k, v: random.choice([0, 1]))
+    utils_test.check_different_keys_threadsafe(z)
+    assert not a
+    assert not b
+    assert not z.key_to_mapping
+    utils_test.check_mapping(z)
+
+
+@pytest.mark.stress
+@pytest.mark.repeat(utils_test.REPEAT_STRESS_TESTS)
+def test_stress_same_key_threadsafe():
+    a = utils_test.SlowDict(0.001)
+    b = utils_test.SlowDict(0.001)
+    z = Sieve({0: a, 1: b}, lambda k, v: random.choice([0, 1]))
+    utils_test.check_same_key_threadsafe(z)
+    assert not a
+    assert not b
+    assert not z.key_to_mapping
+    utils_test.check_mapping(z)

--- a/zict/utils.py
+++ b/zict/utils.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import platform
-import sys
-import threading
-from collections import defaultdict
 from collections.abc import Iterable, Iterator
-from numbers import Number
 from typing import MutableSet  # TODO import from collections.abc (needs Python >=3.9)
 
 from zict.common import T
@@ -70,90 +65,3 @@ class InsertionSortedSet(MutableSet[T]):
 
     def clear(self) -> None:
         self._d.clear()
-
-
-ATOMIC_INT_IADD = (
-    platform.python_implementation() == "CPython" and sys.version_info >= (3, 10)
-)
-
-
-class Accumulator(Number):
-    """A lockless thread-safe accumulator"""
-
-    _values: defaultdict[int, float]
-    __slots__ = ("_values",)
-
-    def __new__(cls, value: float = 0) -> Accumulator:
-        if ATOMIC_INT_IADD:
-            # int.__iadd__ and float.__iadd__ are GIL-atomic starting from CPython 3.10.
-            # We can get rid of the whole class and just use them instead.
-            # This is an implementation detail.
-            return value  # type: ignore[return-value]
-
-        self = object.__new__(cls)
-        # Don't return float unless you actually added floats.
-        # This behaviour is consistent with sum().
-        self._values = defaultdict(int)
-        self._values[threading.get_ident()] = value
-        return self
-
-    def _value(self) -> float:
-        """Return accumulator total across all threads.
-        The return type is float if any float elements were added, otherwise it's int.
-        """
-        while True:
-            try:
-                return sum(self._values.values())
-            except RuntimeError:  # dictionary changed size during iteration
-                pass  # pragma: nocover
-
-    def __iadd__(self, other: float) -> Accumulator:
-        self._values[threading.get_ident()] += other
-        return self
-
-    def __isub__(self, other: float) -> Accumulator:
-        self._values[threading.get_ident()] -= other
-        return self
-
-    # Trivial wrappers around self._value().
-    # Since they are magic methods, they can't be implemented with __getattr__
-    # or with accessor classes.
-
-    def __repr__(self) -> str:
-        return repr(self._value())
-
-    def __int__(self) -> int:
-        return int(self._value())
-
-    def __float__(self) -> float:
-        return float(self._value())
-
-    def __eq__(self, other: object) -> bool:
-        return self._value() == other
-
-    def __gt__(self, other: float) -> bool:
-        return self._value() > other
-
-    def __ge__(self, other: float) -> bool:
-        return self._value() >= other
-
-    def __lt__(self, other: float) -> bool:
-        return self._value() < other
-
-    def __le__(self, other: float) -> bool:
-        return self._value() <= other
-
-    def __add__(self, other: float) -> float:
-        return self._value() + other
-
-    def __sub__(self, other: float) -> float:
-        return self._value() - other
-
-    def __mul__(self, other: float) -> float:
-        return self._value() * other
-
-    def __truediv__(self, other: float) -> float:
-        return self._value() / other
-
-    def __hash__(self) -> int:
-        return hash(self._value())

--- a/zict/zip.py
+++ b/zict/zip.py
@@ -41,6 +41,7 @@ class Zip(MutableMapping[str, bytes]):
     _file: zipfile.ZipFile | None
 
     def __init__(self, filename: str, mode: FileMode = "a"):
+        super().__init__()
         self.filename = filename
         self.mode = mode
         self._file = None


### PR DESCRIPTION
- Partially closes https://github.com/dask/distributed/pull/7686
- The whole lockless thread safety design from #82 and #90 was extremely brittle. This PR swaps it for an industry-standard RLock based design.
- Full thread safety for all classes (except Zip and LMDB), with much less caveats than before
- Follow-up: #99 