### PR TITLE
Thread-safe Buffer.__items__; proper KeysView, ItemsView, ValuesView

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+source =
+    zict
+omit =
+
+[report]
+show_missing = True
+exclude_lines =
+    # re-enable the standard pragma
+    pragma: nocover
+    pragma: no cover
+    # always ignore type checking blocks
+    TYPE_CHECKING
+    @overload
+
+[html]
+directory = coverage_html_report

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,10 +15,12 @@ Changelog
 - ``LMDB`` now uses memory-mapped I/O on MacOSX and is usable on Windows.
   (:pr:`78`) `Guido Imperiale`_
 - The library is now partially thread-safe.
-  (:pr:`82`, :pr:`90`) `Guido Imperiale`_
+  (:pr:`82`, :pr:`90`, :pr:`93`) `Guido Imperiale`_
 - :class:`LRU` and :class:`Buffer` now support delayed eviction.
   New objects :class:`Accumulator` and :class:`InsertionSortedSet`.
   (:pr:`87`) `Guido Imperiale`_
+- All mappings now return proper KeysView, ItemsView, and ValuesView objects from their
+  keys(), items(), and values() methods (:pr:`93`) `Guido Imperiale`_
 
 
 2.2.0 - 2022-04-28

--- a/zict/cache.py
+++ b/zict/cache.py
@@ -67,7 +67,6 @@ class Cache(ZictBase[KT, VT]):
     def __setitem__(self, key: KT, value: VT) -> None:
         # If the item was already in cache and data.__setitem__ fails, e.g. because it's
         # a File and the disk is full, make sure that the cache is invalidated.
-        # FIXME https://github.com/python/mypy/issues/10152
         try:
             del self.cache[key]
         except KeyError:

--- a/zict/cache.py
+++ b/zict/cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import weakref
-from collections.abc import Iterator, KeysView, MutableMapping
+from collections.abc import Iterator, MutableMapping
 from typing import TYPE_CHECKING
 
 from zict.common import KT, VT, ZictBase, close, flush
@@ -92,11 +92,6 @@ class Cache(ZictBase[KT, VT]):
     def __contains__(self, key: object) -> bool:
         # Do not let MutableMapping call self.data[key]
         return key in self.data
-
-    def keys(self) -> KeysView[KT]:
-        # Return a potentially optimized set-like, instead of letting MutableMapping
-        # build it from __iter__ on the fly
-        return self.data.keys()
 
     def flush(self) -> None:
         flush(self.cache, self.data)

--- a/zict/file.py
+++ b/zict/file.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import mmap
 import os
 import pathlib
-from collections.abc import Iterator, KeysView
+from collections.abc import Iterator
 from urllib.parse import quote, unquote
 
 from zict.common import ZictBase
@@ -138,9 +138,6 @@ class File(ZictBase[str, bytes]):
 
     def __contains__(self, key: object) -> bool:
         return key in self.filenames
-
-    def keys(self) -> KeysView[str]:
-        return self.filenames.keys()
 
     def __iter__(self) -> Iterator[str]:
         return iter(self.filenames)

--- a/zict/func.py
+++ b/zict/func.py
@@ -74,13 +74,6 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
     def keys(self) -> KeysView[KT]:
         return self.d.keys()
 
-    # FIXME dictionary views https://github.com/dask/zict/issues/61
-    def values(self) -> Iterator[VT]:  # type: ignore
-        return (self.load(v) for v in self.d.values())
-
-    def items(self) -> Iterator[tuple[KT, VT]]:  # type: ignore
-        return ((k, self.load(v)) for k, v in self.d.items())
-
     def _do_update(self, items: Iterable[tuple[KT, VT]]) -> None:
         it = ((k, self.dump(v)) for k, v in items)
         self.d.update(it)

--- a/zict/func.py
+++ b/zict/func.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Iterator, KeysView, MutableMapping
+from collections.abc import Callable, Iterable, Iterator, MutableMapping
 from typing import Generic, TypeVar
 
 from zict.common import KT, VT, ZictBase, close, flush
@@ -70,9 +70,6 @@ class Func(ZictBase[KT, VT], Generic[KT, VT, WT]):
 
     def __delitem__(self, key: KT) -> None:
         del self.d[key]
-
-    def keys(self) -> KeysView[KT]:
-        return self.d.keys()
 
     def _do_update(self, items: Iterable[tuple[KT, VT]]) -> None:
         it = ((k, self.dump(v)) for k, v in items)

--- a/zict/lmdb.py
+++ b/zict/lmdb.py
@@ -115,7 +115,15 @@ class LMDBItemsView(ItemsView[str, bytes]):
     __slots__ = ()
 
     def __contains__(self, item: object) -> bool:
-        return any(item == v for v in self)
+        key: str
+        value: object
+        key, value = item  # type: ignore
+        try:
+            v = self._mapping[key]
+        except (KeyError, AttributeError):
+            return False
+        else:
+            return v == value
 
     def __iter__(self) -> Iterator[tuple[str, bytes]]:
         cursor = self._mapping.db.begin().cursor()

--- a/zict/sieve.py
+++ b/zict/sieve.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
-from itertools import chain
 from typing import Generic, TypeVar
 
 from zict.common import KT, VT, ZictBase, close, flush
@@ -92,21 +91,11 @@ class Sieve(ZictBase[KT, VT], Generic[KT, VT, MKT]):
             for key, _ in mitems:
                 self.key_to_mapping[key] = mapping
 
-    # FIXME dictionary views https://github.com/dask/zict/issues/61
-    def keys(self) -> Iterator[KT]:  # type: ignore
-        return chain.from_iterable(self.mappings.values())
-
-    def values(self) -> Iterator[VT]:  # type: ignore
-        return chain.from_iterable(m.values() for m in self.mappings.values())
-
-    def items(self) -> Iterator[tuple[KT, VT]]:  # type: ignore
-        return chain.from_iterable(m.items() for m in self.mappings.values())
-
     def __len__(self) -> int:
         return sum(map(len, self.mappings.values()))
 
     def __iter__(self) -> Iterator[KT]:
-        return self.keys()
+        return iter(self.key_to_mapping)
 
     def __contains__(self, key: object) -> bool:
         return key in self.key_to_mapping

--- a/zict/tests/test_buffer.py
+++ b/zict/tests/test_buffer.py
@@ -228,3 +228,17 @@ def test_set_noevict():
     assert a == {"y": 3, "x": 1}
     assert b == {"z": 6}
     assert f2s == s2f == []
+
+
+def test_evict_restore_during_iter():
+    """Test that __iter__ won't be disrupted if another thread evicts or restores a key"""
+    buff = Buffer({"x": 1, "y": 2}, {"z": 3}, n=5)
+    assert list(buff) == ["x", "y", "z"]
+    it = iter(buff)
+    assert next(it) == "x"
+    buff.fast.evict("x")
+    assert next(it) == "y"
+    assert buff["x"] == 1
+    assert next(it) == "z"
+    with pytest.raises(StopIteration):
+        next(it)

--- a/zict/tests/test_cache.py
+++ b/zict/tests/test_cache.py
@@ -4,6 +4,7 @@ from collections import UserDict
 import pytest
 
 from zict import Cache, WeakValueMapping
+from zict.tests import utils_test
 
 
 def test_cache_get_set_del():
@@ -129,3 +130,12 @@ def test_weakvaluemapping():
     b = "bbb"
     d["b"] = b
     assert "b" not in d
+
+
+def test_mapping():
+    """
+    Test mapping interface for Cache().
+    """
+    buff = Cache({}, {})
+    utils_test.check_mapping(buff)
+    utils_test.check_closing(buff)

--- a/zict/tests/test_lru.py
+++ b/zict/tests/test_lru.py
@@ -33,7 +33,7 @@ def test_simple():
     assert "y" not in lru
 
     lru["a"] = 5
-    assert set(lru.keys()) == {"z", "a"}
+    assert set(lru) == {"z", "a"}
 
 
 def test_str():

--- a/zict/tests/test_zip.py
+++ b/zict/tests/test_zip.py
@@ -1,4 +1,3 @@
-import os.path
 import zipfile
 from collections.abc import MutableMapping
 
@@ -10,7 +9,7 @@ from zict.tests import utils_test
 
 @pytest.fixture
 def fn(tmp_path):
-    yield str(tmp_path / "tmp.zip")
+    yield tmp_path / "tmp.zip"
 
 
 def test_simple(fn):

--- a/zict/tests/test_zip.py
+++ b/zict/tests/test_zip.py
@@ -10,7 +10,7 @@ from zict.tests import utils_test
 
 @pytest.fixture
 def fn(tmp_path):
-    yield os.path.join(tmp_path, "tmp.zip")
+    yield str(tmp_path / "tmp.zip")
 
 
 def test_simple(fn):

--- a/zict/tests/utils_test.py
+++ b/zict/tests/utils_test.py
@@ -80,6 +80,7 @@ def stress_test_mapping_updates(z):
 
 
 def check_mapping(z):
+    """See also test_zip.check_mapping"""
     assert type(z).__name__ in str(z)
     assert type(z).__name__ in repr(z)
     assert isinstance(z, MutableMapping)

--- a/zict/tests/utils_test.py
+++ b/zict/tests/utils_test.py
@@ -1,6 +1,6 @@
 import random
 import string
-from collections.abc import MutableMapping
+from collections.abc import ItemsView, KeysView, MutableMapping, ValuesView
 
 import pytest
 
@@ -33,6 +33,19 @@ def check_items(z, expected_items):
     assert list(z.keys()) == [k for k, v in items]
     assert list(z.values()) == [v for k, v in items]
     assert list(z) == [k for k, v in items]
+
+    # ItemsView, KeysView, ValuesView.__contains__()
+    assert isinstance(z.keys(), KeysView)
+    assert isinstance(z.values(), ValuesView)
+    assert isinstance(z.items(), ItemsView)
+    assert items[0] in z.items()
+    assert items[0][0] in z.keys()
+    assert items[0][0] in z
+    assert items[0][1] in z.values()
+    assert (object(), object()) not in z.items()
+    assert object() not in z.keys()
+    assert object() not in z
+    assert object() not in z.values()
 
 
 def stress_test_mapping_updates(z):
@@ -67,6 +80,8 @@ def stress_test_mapping_updates(z):
 
 
 def check_mapping(z):
+    assert type(z).__name__ in str(z)
+    assert type(z).__name__ in repr(z)
     assert isinstance(z, MutableMapping)
     assert not z
 

--- a/zict/zip.py
+++ b/zict/zip.py
@@ -59,20 +59,10 @@ class Zip(MutableMapping[str, bytes]):
     def __setitem__(self, key: str, value: bytes) -> None:
         self.file.writestr(key, value)
 
-    # FIXME dictionary views https://github.com/dask/zict/issues/61
-    def keys(self) -> Iterator[str]:  # type: ignore
+    def __iter__(self) -> Iterator[str]:
         return (zi.filename for zi in self.file.filelist)
 
-    def values(self) -> Iterator[bytes]:  # type: ignore
-        return (self.file.read(key) for key in self.keys())
-
-    def items(self) -> Iterator[tuple[str, bytes]]:  # type: ignore
-        return ((zi.filename, self.file.read(zi.filename)) for zi in self.file.filelist)
-
-    def __iter__(self) -> Iterator[str]:
-        return self.keys()
-
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self, key: str) -> None:  # pragma: nocover
         raise NotImplementedError("Not supported by stdlib zipfile")
 
     def __len__(self) -> int:


### PR DESCRIPTION
- Closes #61 
- Partially closes https://github.com/dask/distributed/issues/4424
- Fix RuntimeError when a thread is iterating on Buffer, e.g. `distributed.worker_state_machine.WorkerStateMachine.validate_state()`, while another is evicting/restoring a key
