### PR TITLE
Replace obsolete tmpdir fixture with tmp_path

### DIFF
--- a/zict/tests/test_lmdb.py
+++ b/zict/tests/test_lmdb.py
@@ -12,66 +12,66 @@ pytest.importorskip("lmdb")
 
 
 @pytest.mark.parametrize("dirtype", [str, pathlib.Path, lambda x: x])
-def test_dirtypes(tmpdir, dirtype):
-    z = LMDB(tmpdir)
+def test_dirtypes(tmp_path, dirtype):
+    z = LMDB(tmp_path)
     z["x"] = b"123"
     assert z["x"] == b"123"
     del z["x"]
 
 
-def test_mapping(tmpdir):
+def test_mapping(tmp_path):
     """
     Test mapping interface for LMDB().
     """
-    z = LMDB(tmpdir)
+    z = LMDB(tmp_path)
     utils_test.check_mapping(z)
 
 
-def test_reuse(tmpdir):
+def test_reuse(tmp_path):
     """
     Test persistence of a LMDB() mapping.
     """
-    with LMDB(tmpdir) as z:
+    with LMDB(tmp_path) as z:
         assert len(z) == 0
         z["abc"] = b"123"
 
-    with LMDB(tmpdir) as z:
+    with LMDB(tmp_path) as z:
         assert len(z) == 1
         assert z["abc"] == b"123"
 
 
-def test_creates_dir(tmpdir):
-    with LMDB(tmpdir):
-        assert os.path.isdir(tmpdir)
+def test_creates_dir(tmp_path):
+    with LMDB(tmp_path):
+        assert os.path.isdir(tmp_path)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="requires psutil.Process.num_fds")
-def test_file_descriptors_dont_leak(tmpdir):
+def test_file_descriptors_dont_leak(tmp_path):
     psutil = pytest.importorskip("psutil")
     proc = psutil.Process()
     before = proc.num_fds()
 
-    z = LMDB(tmpdir)
+    z = LMDB(tmp_path)
     del z
     gc.collect()
 
     assert proc.num_fds() == before
 
-    z = LMDB(tmpdir)
+    z = LMDB(tmp_path)
     z.close()
 
     assert proc.num_fds() == before
 
-    with LMDB(tmpdir) as z:
+    with LMDB(tmp_path) as z:
         pass
 
     assert proc.num_fds() == before
 
 
-def test_map_size(tmpdir):
+def test_map_size(tmp_path):
     import lmdb
 
-    z = LMDB(tmpdir, map_size=2**20)
+    z = LMDB(tmp_path, map_size=2**20)
     z["x"] = b"x" * 2**19
     with pytest.raises(lmdb.MapFullError):
         z["y"] = b"x" * 2**20


### PR DESCRIPTION
https://docs.pytest.org/en/7.2.x/how-to/tmp_path.html#tmpdir-and-tmpdir-factory