### PR TITLE
Enhancements to File, LMDB, Zip

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -21,6 +21,11 @@ Changelog
   (:pr:`87`) `Guido Imperiale`_
 - All mappings now return proper KeysView, ItemsView, and ValuesView objects from their
   keys(), items(), and values() methods (:pr:`93`) `Guido Imperiale`_
+- :class:`File`, :class:`LMDB`, and :class:`Zip` now behave coherently with unexpected
+  key/value types (:pr:`95`) `Guido Imperiale`_
+- ``Zip.__contains__`` no longer reads the value from disk (:pr:`95`) `Guido Imperiale`_
+- ``Zip.__setitem__`` will now raise when updating an already-existing key instead of
+  quietly corrupting the mapping (:pr:`95`) `Guido Imperiale`_
 
 
 2.2.0 - 2022-04-28

--- a/zict/lmdb.py
+++ b/zict/lmdb.py
@@ -65,6 +65,8 @@ class LMDB(ZictBase[str, bytes]):
         )
 
     def __getitem__(self, key: str) -> bytes:
+        if not isinstance(key, str):
+            raise KeyError(key)
         with self.db.begin() as txn:
             value = txn.get(_encode_key(key))
         if value is None:
@@ -72,6 +74,10 @@ class LMDB(ZictBase[str, bytes]):
         return value
 
     def __setitem__(self, key: str, value: bytes) -> None:
+        if not isinstance(key, str):
+            raise TypeError(key)
+        if not isinstance(value, bytes):
+            raise TypeError(value)
         with self.db.begin(write=True) as txn:
             txn.put(_encode_key(key), value)
 
@@ -93,12 +99,21 @@ class LMDB(ZictBase[str, bytes]):
 
     def _do_update(self, items: Iterable[tuple[str, bytes]]) -> None:
         # Optimized version of update() using a single putmulti() call.
-        items_enc = [(_encode_key(k), v) for k, v in items]
+        items_enc = []
+        for key, value in items:
+            if not isinstance(key, str):
+                raise TypeError(key)
+            if not isinstance(value, bytes):
+                raise TypeError(value)
+            items_enc.append((_encode_key(key), value))
+
         with self.db.begin(write=True) as txn:
             consumed, added = txn.cursor().putmulti(items_enc)
             assert consumed == added == len(items_enc)
 
     def __delitem__(self, key: str) -> None:
+        if not isinstance(key, str):
+            raise KeyError(key)
         with self.db.begin(write=True) as txn:
             if not txn.delete(_encode_key(key)):
                 raise KeyError(key)
@@ -120,7 +135,7 @@ class LMDBItemsView(ItemsView[str, bytes]):
         key, value = item  # type: ignore
         try:
             v = self._mapping[key]
-        except (KeyError, AttributeError):
+        except KeyError:
             return False
         else:
             return v == value

--- a/zict/tests/conftest.py
+++ b/zict/tests/conftest.py
@@ -1,0 +1,21 @@
+import gc
+import sys
+
+import pytest
+
+try:
+    import psutil
+except ImportError:
+    psutil = None  # type: ignore
+
+
+@pytest.fixture
+def check_fd_leaks():
+    if sys.platform == "win32" or psutil is None:
+        yield
+    else:
+        proc = psutil.Process()
+        before = proc.num_fds()
+        yield
+        gc.collect()
+        assert proc.num_fds() == before

--- a/zict/tests/test_file.py
+++ b/zict/tests/test_file.py
@@ -10,7 +10,7 @@ from zict import File
 from zict.tests import utils_test
 
 
-def test_mapping(tmp_path):
+def test_mapping(tmp_path, check_fd_leaks):
     """
     Test mapping interface for File().
     """
@@ -19,7 +19,7 @@ def test_mapping(tmp_path):
 
 
 @pytest.mark.parametrize("dirtype", [str, pathlib.Path, lambda x: x])
-def test_implementation(tmp_path, dirtype):
+def test_implementation(tmp_path, check_fd_leaks, dirtype):
     z = File(dirtype(tmp_path))
     assert not z
 
@@ -34,7 +34,7 @@ def test_implementation(tmp_path, dirtype):
     assert out == b"123"
 
 
-def test_memmap_implementation(tmp_path):
+def test_memmap_implementation(tmp_path, check_fd_leaks):
     z = File(tmp_path, memmap=True)
     assert not z
 
@@ -50,18 +50,18 @@ def test_memmap_implementation(tmp_path):
     assert mv2 == b"223"
 
 
-def test_str(tmp_path):
+def test_str(tmp_path, check_fd_leaks):
     z = File(tmp_path)
     assert str(z) == repr(z) == f"<File: {tmp_path}, 0 elements>"
 
 
-def test_setitem_typeerror(tmp_path):
+def test_setitem_typeerror(tmp_path, check_fd_leaks):
     z = File(tmp_path)
     with pytest.raises(TypeError):
         z["x"] = 123
 
 
-def test_contextmanager(tmp_path):
+def test_contextmanager(tmp_path, check_fd_leaks):
     with File(tmp_path) as z:
         z["x"] = b"123"
 
@@ -69,7 +69,7 @@ def test_contextmanager(tmp_path):
         assert fh.read() == b"123"
 
 
-def test_delitem(tmp_path):
+def test_delitem(tmp_path, check_fd_leaks):
     z = File(tmp_path)
 
     z["x"] = b"123"
@@ -84,14 +84,14 @@ def test_delitem(tmp_path):
     assert os.listdir(tmp_path) == ["x#2"]
 
 
-def test_missing_key(tmp_path):
+def test_missing_key(tmp_path, check_fd_leaks):
     z = File(tmp_path)
 
     with pytest.raises(KeyError):
         z["x"]
 
 
-def test_arbitrary_chars(tmp_path):
+def test_arbitrary_chars(tmp_path, check_fd_leaks):
     z = File(tmp_path)
 
     # Avoid hitting the Windows max filename length
@@ -120,14 +120,20 @@ def test_arbitrary_chars(tmp_path):
             z[key]
 
 
-def test_write_list_of_bytes(tmp_path):
+def test_write_list_of_bytes(tmp_path, check_fd_leaks):
     z = File(tmp_path)
 
     z["x"] = [b"123", b"4567"]
     assert z["x"] == b"1234567"
 
 
-def test_different_keys_threadsafe(tmp_path):
+def test_bad_types(tmp_path, check_fd_leaks):
+    z = File(tmp_path)
+    utils_test.check_bad_key_types(z)
+    utils_test.check_bad_value_types(z)
+
+
+def test_different_keys_threadsafe(tmp_path, check_fd_leaks):
     """File is fully thread-safe as long as different threads operate on different keys"""
     z = File(tmp_path)
     barrier = Barrier(2)

--- a/zict/zip.py
+++ b/zict/zip.py
@@ -54,13 +54,30 @@ class Zip(MutableMapping[str, bytes]):
         return self._file
 
     def __getitem__(self, key: str) -> bytes:
+        if not isinstance(key, str):
+            raise KeyError(key)
         return self.file.read(key)
 
-    def __setitem__(self, key: str, value: bytes) -> None:
+    def __setitem__(self, key: str, value: bytes | bytearray | memoryview) -> None:
+        if not isinstance(key, str):
+            raise TypeError(key)
+        if not isinstance(value, (bytes, bytearray, memoryview)):
+            raise TypeError(value)
+        if key in self:
+            raise NotImplementedError("Not supported by stdlib zipfile")
         self.file.writestr(key, value)
 
     def __iter__(self) -> Iterator[str]:
         return (zi.filename for zi in self.file.filelist)
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        try:
+            self.file.getinfo(key)
+            return True
+        except KeyError:
+            return False
 
     def __delitem__(self, key: str) -> None:  # pragma: nocover
         raise NotImplementedError("Not supported by stdlib zipfile")


### PR DESCRIPTION
- Robustly check key/value types in File, LMDB, Zip
- Thoroughly check for file descriptor leaks
- ``Zip.__contains__`` no longer reads the value from disk
- ``Zip.__setitem__`` will now raise when updating an already-existing key instead of quietly corrupting the mapping
